### PR TITLE
Fix excessive parameter extraction causing scan to hang

### DIFF
--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -631,6 +631,14 @@ async fn execute_standalone_scan(
         }
     }
 
+    // Limit parameters to prevent excessive testing (max 100 params for performance)
+    const MAX_PARAMS_TO_TEST: usize = 100;
+    let original_count = test_params.len();
+    if test_params.len() > MAX_PARAMS_TO_TEST {
+        info!("  [NOTE] Limiting parameter tests from {} to {} (max limit)", original_count, MAX_PARAMS_TO_TEST);
+        test_params.truncate(MAX_PARAMS_TO_TEST);
+    }
+
     // Only test parameters that actually exist
     let has_real_params = !test_params.is_empty();
 


### PR DESCRIPTION
- Remove overly aggressive JSON keys pattern that matched all keys in JS files
- Add comprehensive JS noise filter (keywords, methods, framework terms, variable names)
- Only look for security-relevant params in actual input contexts (name=, ?param=, $var)
- Add MAX_PARAMS_TO_TEST limit (100) to prevent hanging on noisy extractions
- Expand security_params list with auth, redirect, file, and injection-relevant params