### PR TITLE
Add aggressive Next.js form field extraction

### DIFF
--- a/src/scanners/js_miner.rs
+++ b/src/scanners/js_miner.rs
@@ -343,6 +343,12 @@ impl JsMinerScanner {
             // Also extract endpoints and params from JS content
             if let Ok(response) = self.http_client.get(&js_url).await {
                 self.extract_endpoints_and_params(&response.body, &mut results);
+
+                // For Next.js page bundles, do aggressive form field extraction
+                if js_url.contains("_next/static/chunks/app/page") ||
+                   js_url.contains("_next/static/chunks/pages/") {
+                    self.extract_nextjs_form_fields(&response.body, &mut results);
+                }
             }
         }
 
@@ -1466,6 +1472,82 @@ impl JsMinerScanner {
 
     /// Check if a parameter name looks like minified/webpack garbage or framework internal
     /// Returns true if we should SKIP this parameter
+    /// Extract form fields specifically from Next.js page bundles
+    /// This is aggressive - it looks for ALL common form field string patterns
+    fn extract_nextjs_form_fields(&self, content: &str, results: &mut JsMinerResults) {
+        // Known form field names to look for in minified bundles
+        // These appear as string literals: "email", "password", etc.
+        let known_form_fields = [
+            "email", "password", "username", "phone", "telephone", "mobile",
+            "message", "subject", "comment", "feedback", "inquiry",
+            "firstName", "lastName", "fullName", "name",
+            "first_name", "last_name", "full_name",
+            "company", "organization", "business",
+            "address", "street", "city", "state", "country", "zip", "postal",
+            "zipcode", "postcode", "postalcode",
+            "website", "url", "linkedin", "twitter",
+            "budget", "amount", "price",
+            "description", "details", "notes",
+            "contactName", "contactEmail", "contactPhone",
+            "companyName", "companyEmail",
+            // Finnish
+            "nimi", "sähköposti", "puhelin", "viesti", "osoite", "kaupunki",
+            "postinumero", "yritys", "aihe", "kuvaus", "kommentti",
+            // Auth related
+            "login", "signin", "signup", "register",
+            "oldPassword", "newPassword", "confirmPassword", "password_confirmation",
+            "currentPassword", "old_password", "new_password", "confirm_password",
+        ];
+
+        let content_lower = content.to_lowercase();
+
+        for field in known_form_fields {
+            // Look for the field name as a quoted string literal
+            // Pattern: "email" or 'email' or `email`
+            let patterns = [
+                format!(r#"["']{}["']"#, field),
+                format!(r#"["']{}["']\s*:"#, field),  // Object key: "email":
+                format!(r#"name\s*[:=]\s*["']{}["']"#, field),  // name: "email" or name="email"
+            ];
+
+            for pattern in &patterns {
+                if let Ok(re) = Regex::new(pattern) {
+                    if re.is_match(&content_lower) {
+                        debug!("[Next.js] Found form field: {}", field);
+                        results.parameters.entry("*".to_string())
+                            .or_insert_with(HashSet::new)
+                            .insert(field.to_string());
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Also look for form-related API endpoints specific to Next.js
+        let nextjs_api_patterns = [
+            r#"/api/(?:contact|submit|form|send|message|inquiry)"#,
+            r#"/api/(?:auth|login|signup|register)"#,
+            r#"action\s*[:=]\s*["'](/api/[^"']+)["']"#,
+        ];
+
+        for pattern in nextjs_api_patterns {
+            if let Ok(re) = Regex::new(pattern) {
+                for cap in re.captures_iter(content) {
+                    if let Some(endpoint) = cap.get(1).or(cap.get(0)) {
+                        let ep = endpoint.as_str().to_string();
+                        if ep.starts_with('/') {
+                            results.api_endpoints.insert(ep.clone());
+                            results.form_actions.insert(ep);
+                        }
+                    }
+                }
+            }
+        }
+
+        debug!("[Next.js] Extracted {} form fields from page bundle",
+               results.parameters.get("*").map(|s| s.len()).unwrap_or(0));
+    }
+
     fn is_minified_param(name: &str) -> bool {
         // Too short - likely minified
         if name.len() < 3 {


### PR DESCRIPTION
- Add extract_nextjs_form_fields() for page bundles
- Look for known form field strings in minified JS
- Scan _next/static/chunks/app/page-*.js and pages/ bundles
- Support Finnish form field names
- Extract Next.js API endpoints (/api/contact, /api/submit, etc.)