### PR TITLE
fix: enable crawling in scheduled scan workflow

### DIFF
--- a/.github/workflows/scheduled-scan.yml
+++ b/.github/workflows/scheduled-scan.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Scan training endpoint
         run: |
           lonkero scan \
+            --crawl \
             --format json \
             --output lonkero-results.json \
             https://training-data-lonkero.bountyy-fi-clients.workers.dev/


### PR DESCRIPTION
Add --crawl flag so lonkero discovers and tests all URLs on the training endpoint, not just the root page.