### PR TITLE
fix: remove patch version from rust-version MSRV requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lonkero"
 version = "3.4.0"
-rust-version = "1.85.1"
+rust-version = "1.85"
 edition = "2021"
 authors = ["Bountyy Oy <info@bountyy.fi>"]
 description = "Web scanner built for actual pentests. Fast, modular, Rust."


### PR DESCRIPTION
The rust-version field should not include the patch version (x.y.z) as patch versions don't affect API compatibility. Using "1.85" instead of "1.85.1" ensures users with Rust 1.85.0 or any 1.85.x can install the crate via `cargo install lonkero`.