### PR TITLE
fix: disable aggressive anti-tamper checks blocking Professional license

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,7 +1976,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lonkero"
-version = "3.5.0"
+version = "3.5.7"
 dependencies = [
  "ahash",
  "anyhow",


### PR DESCRIPTION
Issue: Professional license holders were incorrectly denied access to premium
features like "Advanced API fuzzing" due to overly aggressive anti-tamper
checks that had false positives.

Root cause: The is_feature_available() function called multiple anti-tamper
checks (was_tampered, full_integrity_check, verify_no_hook, is_validated,
verify_magic_constants) that could fail even for legitimate licensed users,
particularly verify_magic_constants() which was the main blocker.

Solution:
- Disabled aggressive anti-tamper checks in is_feature_available()
- Removed verify_magic_constants() calls, replaced with direct return true
- License validation via server is still enforced (secure and reliable)
- Only license type and feature restrictions are checked now

This prevents false positives while maintaining security through server-side
license validation.

Affected: src/license/mod.rs