### PR TITLE
Replace federated learning with one-way model distribution API and ad…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,7 +2095,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lonkero"
-version = "3.6.1"
+version = "3.6.2"
 dependencies = [
  "ahash",
  "anyhow",

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -265,11 +265,7 @@ enum LicenseAction {
 #[derive(Subcommand)]
 enum MlAction {
     /// Enable ML features with GDPR consent
-    Enable {
-        /// Also opt-in to federated learning (share model weights to improve detection for all users)
-        #[arg(long)]
-        federated: bool,
-    },
+    Enable,
     /// Disable ML features
     Disable {
         /// Also delete all collected training data
@@ -286,7 +282,7 @@ enum MlAction {
     },
     /// Delete all ML data (GDPR Article 17 - Right to erasure)
     DeleteData,
-    /// Manually sync with federated network
+    /// Fetch latest detection model from server
     Sync,
 }
 
@@ -803,7 +799,7 @@ async fn handle_ml_command(action: MlAction) -> Result<()> {
     use lonkero_scanner::ml::{MlPipeline, PrivacyManager};
 
     match action {
-        MlAction::Enable { federated } => {
+        MlAction::Enable => {
             println!();
             println!("========================================================");
             println!("LONKERO ML - GDPR CONSENT");
@@ -816,31 +812,19 @@ async fn handle_ml_command(action: MlAction) -> Result<()> {
             println!("     - Only statistical features (response codes, timing, etc.)");
             println!("     - Data stored in ~/.lonkero/training_data/");
             println!();
-
-            if federated {
-                println!("  2. Federated Learning (you opted in with --federated):");
-                println!("     - Model WEIGHTS are shared (not your actual data)");
-                println!("     - Differential privacy noise applied before sharing");
-                println!("     - Cannot reconstruct your findings from weights");
-                println!("     - Benefits: Better detection accuracy for everyone");
-                println!();
-            }
+            println!("  2. Detection model download from Bountyy servers");
+            println!("     - Latest model weights are fetched (requires valid license)");
+            println!("     - No data is uploaded from your machine");
+            println!();
 
             println!("You can withdraw consent at any time with: lonkero ml disable");
             println!("You can delete all data with: lonkero ml delete-data");
             println!();
 
             let mut privacy = PrivacyManager::new()?;
-            privacy.record_consent(federated)?;
+            privacy.record_consent(false)?;
 
-            println!(
-                "[OK] ML features enabled{}",
-                if federated {
-                    " with federated learning"
-                } else {
-                    ""
-                }
-            );
+            println!("[OK] ML features enabled");
             println!();
         }
 
@@ -879,22 +863,14 @@ async fn handle_ml_command(action: MlAction) -> Result<()> {
                     println!("  Pending:           {}", stats.pending_learning);
                     println!("  Endpoint patterns: {}", stats.endpoint_patterns);
                     println!();
-                    println!("Federated Learning:");
+                    println!("Detection Model:");
                     println!(
-                        "  Connected:         {}",
-                        if stats.federated_enabled { "Yes" } else { "No" }
+                        "  Available:         {}",
+                        if stats.model_available { "Yes" } else { "No" }
                     );
-                    if let Some(contributors) = stats.federated_contributors {
+                    if let Some(contributors) = stats.model_contributors {
                         println!("  Contributors:      {}", contributors);
                     }
-                    println!(
-                        "  Can contribute:    {}",
-                        if stats.can_contribute {
-                            "Yes (50+ examples)"
-                        } else {
-                            "No (need 50+ examples)"
-                        }
-                    );
                 }
                 Err(e) => {
                     println!("ML not initialized: {}", e);
@@ -939,21 +915,13 @@ async fn handle_ml_command(action: MlAction) -> Result<()> {
         }
 
         MlAction::Sync => {
-            println!("Syncing with federated network...");
-
-            let privacy = PrivacyManager::new()?;
-            if !privacy.is_federated_allowed() {
-                println!();
-                println!("Federated learning not enabled.");
-                println!("Enable with: lonkero ml enable --federated");
-                return Ok(());
-            }
+            println!("Fetching latest detection model...");
 
             match MlPipeline::new() {
                 Ok(mut pipeline) => {
                     pipeline.on_scan_complete().await?;
                     println!();
-                    println!("[OK] Sync complete");
+                    println!("[OK] Detection model sync complete");
                 }
                 Err(e) => {
                     error!("Sync failed: {}", e);
@@ -1431,21 +1399,21 @@ async fn run_scan(
                         );
                     }
 
-                    // Signal scan completion to trigger federated sync
+                    // Signal scan completion to trigger model sync
                     if let Err(e) = ml_pipeline.on_scan_complete().await {
                         warn!("[ML] Failed to complete scan processing: {}", e);
                     } else {
                         let stats = ml_pipeline.get_stats().await;
-                        if stats.federated_enabled || stats.can_contribute {
+                        if stats.model_available {
                             info!(
-                                "[ML] Federated sync complete (contributors: {:?})",
-                                stats.federated_contributors
+                                "[ML] Detection model sync complete (contributors: {:?})",
+                                stats.model_contributors
                             );
                         }
                     }
                 } else {
                     debug!(
-                        "[ML] Auto-learning disabled - enable with: lonkero ml enable --federated"
+                        "[ML] Auto-learning disabled - enable with: lonkero ml enable"
                     );
                 }
             }

--- a/src/features/cmdi.rs
+++ b/src/features/cmdi.rs
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Bountyy Oy. All rights reserved.
+// This software is proprietary and confidential.
+
+use super::ProbeContext;
+use std::collections::HashMap;
+
+/// Extract Command Injection features from a probe response
+pub fn extract_cmdi_features(ctx: &ProbeContext, features: &mut HashMap<String, f64>) {
+    let body = &ctx.response.body;
+    let body_lower = body.to_lowercase();
+
+    // cmdi:os_output_detected - common OS command output patterns
+    let os_patterns = [
+        "uid=",              // id command
+        "root:x:",           // /etc/passwd
+        "www-data",          // Linux user
+        "total ",            // ls -la output
+        "drwx",              // directory listing
+        "Directory of",      // Windows dir command
+        "Volume Serial",     // Windows dir command
+        "Windows IP Config", // ipconfig
+        "inet ",             // ifconfig
+    ];
+
+    for pattern in &os_patterns {
+        if body.contains(pattern) && !ctx.baseline.body.contains(pattern) {
+            features.insert("cmdi:os_output_detected".into(), 0.95);
+            break;
+        }
+    }
+
+    // cmdi:etc_passwd_leaked
+    if body.contains("root:x:0:0") || body.contains("root:*:0:0") {
+        features.insert("cmdi:etc_passwd_leaked".into(), 1.0);
+    }
+
+    // cmdi:command_error_message
+    let cmd_errors = [
+        "command not found",
+        "not recognized as an internal",
+        "sh: ",
+        "bash: ",
+        "cmd.exe",
+        "Permission denied",
+        "No such file or directory",
+    ];
+    for err in &cmd_errors {
+        if body_lower.contains(&err.to_lowercase()) && !ctx.baseline.body.to_lowercase().contains(&err.to_lowercase()) {
+            features.insert("cmdi:command_error_message".into(), 0.85);
+            break;
+        }
+    }
+
+    // Time-based detection for command injection
+    if let Some(injected_delay) = ctx.injected_delay {
+        let actual_delay_s = (ctx.response.response_time_ms as f64) / 1000.0;
+        let baseline_s = (ctx.baseline.response_time_ms as f64) / 1000.0;
+        let extra_delay = actual_delay_s - baseline_s;
+
+        if extra_delay > (injected_delay * 0.7) {
+            features.insert(
+                "cmdi:time_delay_detected".into(),
+                (extra_delay / injected_delay).min(1.0),
+            );
+        }
+    }
+
+    // cmdi:waf_blocked
+    if ctx.response.status == 403
+        || body_lower.contains("blocked")
+        || body_lower.contains("waf")
+        || body_lower.contains("firewall")
+    {
+        features.insert("cmdi:waf_blocked".into(), 1.0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::*;
+    use super::*;
+
+    #[test]
+    fn test_etc_passwd_leak() {
+        let response = make_response("root:x:0:0:root:/root:/bin/bash\ndaemon:x:1:1:", 200);
+        let ctx = make_ctx("cmdi", ";cat /etc/passwd", response);
+        let mut features = HashMap::new();
+        extract_cmdi_features(&ctx, &mut features);
+
+        assert!(features.contains_key("cmdi:etc_passwd_leaked"));
+        assert!(features.contains_key("cmdi:os_output_detected"));
+    }
+
+    #[test]
+    fn test_command_error() {
+        let response = make_response("sh: 1: test_cmd: not found", 200);
+        let ctx = make_ctx("cmdi", ";test_cmd", response);
+        let mut features = HashMap::new();
+        extract_cmdi_features(&ctx, &mut features);
+
+        assert!(features.contains_key("cmdi:command_error_message"));
+    }
+
+    #[test]
+    fn test_cmdi_time_based() {
+        let mut response = make_response("OK", 200);
+        response.response_time_ms = 5100;
+        let mut ctx = make_ctx("cmdi", ";sleep 5", response);
+        ctx.injected_delay = Some(5.0);
+        ctx.baseline.response_time_ms = 100;
+
+        let mut features = HashMap::new();
+        extract_cmdi_features(&ctx, &mut features);
+
+        assert!(features.contains_key("cmdi:time_delay_detected"));
+    }
+}

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -1,0 +1,161 @@
+// Copyright (c) 2026 Bountyy Oy. All rights reserved.
+// This software is proprietary and confidential.
+
+/**
+ * Bountyy Oy - Feature Extraction Layer
+ * Analyzes HTTP probe responses and maps signals to model feature keys
+ *
+ * Each extractor takes a ProbeContext and returns a HashMap of feature keys
+ * to values (0.0-1.0). Feature keys must match the model weight keys exactly.
+ *
+ * @copyright 2026 Bountyy Oy
+ * @license Proprietary
+ */
+pub mod cmdi;
+pub mod signals;
+pub mod sqli;
+pub mod ssti;
+pub mod traversal;
+pub mod xss;
+
+use std::collections::HashMap;
+
+/// Location of the parameter being tested
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParamLocation {
+    Query,
+    Body,
+    Header,
+    Path,
+    Cookie,
+}
+
+/// HTTP response data for feature extraction
+#[derive(Debug, Clone)]
+pub struct HttpResponse {
+    pub status: u16,
+    pub headers: HashMap<String, String>,
+    pub body: String,
+    pub body_bytes: usize,
+    pub response_time_ms: u64,
+}
+
+impl HttpResponse {
+    /// Create from the crate's HttpResponse type
+    pub fn from_client_response(resp: &crate::http_client::HttpResponse) -> Self {
+        Self {
+            status: resp.status_code,
+            headers: resp.headers.clone(),
+            body: resp.body.clone(),
+            body_bytes: resp.body.len(),
+            response_time_ms: resp.duration_ms,
+        }
+    }
+}
+
+/// Context for probe feature extraction
+#[derive(Debug, Clone)]
+pub struct ProbeContext {
+    /// What was injected
+    pub probe_payload: String,
+    /// Category: "sqli", "xss", "ssti", "cmdi", "ssrf", "traversal", etc.
+    pub probe_category: String,
+    /// Which parameter was tested
+    pub param_name: String,
+    /// Where the parameter is located
+    pub param_location: ParamLocation,
+    /// Full request URL
+    pub request_url: String,
+    /// HTTP method used
+    pub request_method: String,
+    /// Response to the probe request
+    pub response: HttpResponse,
+    /// Normal response without injection (baseline)
+    pub baseline: HttpResponse,
+    /// For time-based probes: expected delay in seconds
+    pub injected_delay: Option<f64>,
+}
+
+/// Extract features from a probe context.
+/// Returns a HashMap of feature keys (e.g. "sqli:error_mysql_syntax") to
+/// values between 0.0 and 1.0.
+pub fn extract_features(ctx: &ProbeContext) -> HashMap<String, f64> {
+    let mut features = HashMap::new();
+
+    // Run category-specific extractors based on probe type
+    match ctx.probe_category.as_str() {
+        "sqli" => sqli::extract_sqli_features(ctx, &mut features),
+        "xss" => xss::extract_xss_features(ctx, &mut features),
+        "ssti" => ssti::extract_ssti_features(ctx, &mut features),
+        "cmdi" => cmdi::extract_cmdi_features(ctx, &mut features),
+        "traversal" => traversal::extract_traversal_features(ctx, &mut features),
+        _ => {}
+    }
+
+    // Always run cross-cutting signal extractors
+    signals::extract_signal_features(ctx, &mut features);
+
+    features
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    pub fn make_baseline() -> HttpResponse {
+        HttpResponse {
+            status: 200,
+            headers: HashMap::new(),
+            body: "<html><body>Normal page</body></html>".to_string(),
+            body_bytes: 36,
+            response_time_ms: 100,
+        }
+    }
+
+    pub fn make_response(body: &str, status: u16) -> HttpResponse {
+        HttpResponse {
+            status,
+            headers: HashMap::new(),
+            body: body.to_string(),
+            body_bytes: body.len(),
+            response_time_ms: 100,
+        }
+    }
+
+    pub fn make_ctx(category: &str, payload: &str, response: HttpResponse) -> ProbeContext {
+        ProbeContext {
+            probe_payload: payload.to_string(),
+            probe_category: category.to_string(),
+            param_name: "id".to_string(),
+            param_location: ParamLocation::Query,
+            request_url: "https://example.com/test".to_string(),
+            request_method: "GET".to_string(),
+            response,
+            baseline: make_baseline(),
+            injected_delay: None,
+        }
+    }
+
+    #[test]
+    fn test_extract_features_sqli() {
+        let response = make_response(
+            "You have an error in your SQL syntax near '1'",
+            500,
+        );
+        let ctx = make_ctx("sqli", "'", response);
+        let features = extract_features(&ctx);
+
+        assert!(features.contains_key("sqli:error_mysql_syntax"));
+        assert!(features.contains_key("signal:error_triggered"));
+    }
+
+    #[test]
+    fn test_extract_features_unknown_category() {
+        let response = make_response("OK", 200);
+        let ctx = make_ctx("unknown", "test", response);
+        let features = extract_features(&ctx);
+
+        // Should still have signal features
+        assert!(!features.contains_key("sqli:error_mysql_syntax"));
+    }
+}

--- a/src/features/signals.rs
+++ b/src/features/signals.rs
@@ -1,0 +1,172 @@
+// Copyright (c) 2026 Bountyy Oy. All rights reserved.
+// This software is proprietary and confidential.
+
+use super::ProbeContext;
+use std::collections::HashMap;
+
+/// Extract cross-cutting signal features that apply to all probe categories
+pub fn extract_signal_features(ctx: &ProbeContext, features: &mut HashMap<String, f64>) {
+    // signal:response_code_anomaly
+    if ctx.response.status != ctx.baseline.status {
+        features.insert("signal:response_code_anomaly".into(), 1.0);
+    }
+
+    // signal:response_size_anomaly
+    let size_diff =
+        (ctx.response.body_bytes as f64 - ctx.baseline.body_bytes as f64).abs();
+    let size_ratio = size_diff / ctx.baseline.body_bytes.max(1) as f64;
+    if size_ratio > 0.1 {
+        features.insert("signal:response_size_anomaly".into(), size_ratio.min(1.0));
+    }
+
+    // signal:response_time_anomaly
+    let time_ratio =
+        ctx.response.response_time_ms as f64 / ctx.baseline.response_time_ms.max(1) as f64;
+    if time_ratio > 2.0 || time_ratio < 0.3 {
+        features.insert(
+            "signal:response_time_anomaly".into(),
+            ((time_ratio - 1.0).abs() / 5.0).min(1.0),
+        );
+    }
+
+    // signal:error_triggered
+    if ctx.response.status >= 400 && ctx.baseline.status < 400 {
+        features.insert("signal:error_triggered".into(), 1.0);
+    }
+
+    // signal:input_reflected_anywhere
+    if ctx.response.body.contains(&ctx.probe_payload) {
+        features.insert("signal:input_reflected_anywhere".into(), 1.0);
+        features.insert("signal:canary_token_reflected".into(), 1.0);
+    }
+
+    // signal:waf_detected
+    let waf_indicators = [
+        "mod_security",
+        "cloudflare",
+        "akamai",
+        "imperva",
+        "sucuri",
+        "f5 big-ip",
+        "barracuda",
+        "fortiweb",
+    ];
+    let body_lower = ctx.response.body.to_lowercase();
+    let server = ctx
+        .response
+        .headers
+        .get("server")
+        .map(|s| s.to_lowercase())
+        .unwrap_or_default();
+    for waf in &waf_indicators {
+        if body_lower.contains(waf) || server.contains(waf) {
+            features.insert("signal:waf_detected".into(), 1.0);
+            break;
+        }
+    }
+
+    // signal:custom_error_page
+    if ctx.response.status >= 400
+        && ctx.response.body_bytes > 1000
+        && !body_lower.contains("stack trace")
+        && !body_lower.contains("traceback")
+    {
+        features.insert("signal:custom_error_page".into(), 1.0);
+    }
+
+    // signal:content_type_mismatch
+    if let Some(ct) = ctx.response.headers.get("content-type") {
+        if (ct.contains("json") && ctx.response.body.starts_with('<'))
+            || (ct.contains("html") && ctx.response.body.starts_with('{'))
+        {
+            features.insert("signal:content_type_mismatch".into(), 1.0);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::*;
+    use super::*;
+
+    #[test]
+    fn test_error_triggered() {
+        let response = make_response("Internal Server Error", 500);
+        let ctx = make_ctx("sqli", "'", response);
+        let mut features = HashMap::new();
+        extract_signal_features(&ctx, &mut features);
+
+        assert!(features.contains_key("signal:error_triggered"));
+        assert!(features.contains_key("signal:response_code_anomaly"));
+    }
+
+    #[test]
+    fn test_input_reflected() {
+        let response = make_response("You searched for: <script>alert(1)</script>", 200);
+        let ctx = make_ctx("xss", "<script>alert(1)</script>", response);
+        let mut features = HashMap::new();
+        extract_signal_features(&ctx, &mut features);
+
+        assert!(features.contains_key("signal:input_reflected_anywhere"));
+    }
+
+    #[test]
+    fn test_response_size_anomaly() {
+        let mut response = make_response(&"x".repeat(500), 200);
+        response.body_bytes = 500;
+        let ctx = make_ctx("sqli", "'", response);
+        let mut features = HashMap::new();
+        extract_signal_features(&ctx, &mut features);
+
+        assert!(features.contains_key("signal:response_size_anomaly"));
+    }
+
+    #[test]
+    fn test_response_time_anomaly() {
+        let mut response = make_response("OK", 200);
+        response.response_time_ms = 5000;
+        let ctx = make_ctx("sqli", "' AND SLEEP(5)--", response);
+        let mut features = HashMap::new();
+        extract_signal_features(&ctx, &mut features);
+
+        assert!(features.contains_key("signal:response_time_anomaly"));
+    }
+
+    #[test]
+    fn test_waf_detected() {
+        let mut response = make_response("Blocked by security", 200);
+        response
+            .headers
+            .insert("server".to_string(), "cloudflare".to_string());
+        let ctx = make_ctx("sqli", "'", response);
+        let mut features = HashMap::new();
+        extract_signal_features(&ctx, &mut features);
+
+        assert!(features.contains_key("signal:waf_detected"));
+    }
+
+    #[test]
+    fn test_content_type_mismatch() {
+        let mut response = make_response("{\"error\": true}", 200);
+        response.headers.insert(
+            "content-type".to_string(),
+            "text/html; charset=utf-8".to_string(),
+        );
+        let ctx = make_ctx("sqli", "'", response);
+        let mut features = HashMap::new();
+        extract_signal_features(&ctx, &mut features);
+
+        assert!(features.contains_key("signal:content_type_mismatch"));
+    }
+
+    #[test]
+    fn test_no_anomaly_on_normal_response() {
+        let response = make_response("<html><body>Normal page</body></html>", 200);
+        let ctx = make_ctx("sqli", "'", response);
+        let mut features = HashMap::new();
+        extract_signal_features(&ctx, &mut features);
+
+        assert!(!features.contains_key("signal:error_triggered"));
+        assert!(!features.contains_key("signal:response_code_anomaly"));
+    }
+}

--- a/src/features/sqli.rs
+++ b/src/features/sqli.rs
@@ -1,0 +1,224 @@
+// Copyright (c) 2026 Bountyy Oy. All rights reserved.
+// This software is proprietary and confidential.
+
+use super::ProbeContext;
+use std::collections::HashMap;
+
+/// Extract SQL injection features from a probe response
+pub fn extract_sqli_features(ctx: &ProbeContext, features: &mut HashMap<String, f64>) {
+    let body = &ctx.response.body;
+    let body_lower = body.to_lowercase();
+
+    // Error-based: check for database error patterns in response
+
+    // sqli:error_mysql_syntax
+    if body.contains("You have an error in your SQL syntax")
+        || body.contains("mysql_fetch")
+        || body.contains("mysqli_")
+    {
+        features.insert("sqli:error_mysql_syntax".into(), 0.95);
+    }
+
+    // sqli:error_postgresql_syntax
+    if body.contains("ERROR: syntax error at or near")
+        || body.contains("pg_query")
+        || body.contains("PG::SyntaxError")
+    {
+        features.insert("sqli:error_postgresql_syntax".into(), 0.95);
+    }
+
+    // sqli:error_mssql_syntax
+    if body.contains("Unclosed quotation mark")
+        || body.contains("mssql_query")
+        || body.contains("Microsoft OLE DB")
+    {
+        features.insert("sqli:error_mssql_syntax".into(), 0.95);
+    }
+
+    // sqli:error_oracle_syntax
+    if body.contains("ORA-01756")
+        || body.contains("ORA-00933")
+        || body.contains("Oracle error")
+    {
+        features.insert("sqli:error_oracle_syntax".into(), 0.95);
+    }
+
+    // sqli:error_sqlite_syntax
+    if body.contains("SQLITE_ERROR")
+        || (body.contains("near \"") && body.contains("syntax error"))
+    {
+        features.insert("sqli:error_sqlite_syntax".into(), 0.95);
+    }
+
+    // sqli:stack_trace_with_query - SQL query visible in stack trace
+    if (body.contains("SELECT") || body.contains("INSERT") || body.contains("UPDATE"))
+        && (body.contains("at line")
+            || body.contains("stacktrace")
+            || body.contains("Traceback"))
+    {
+        features.insert("sqli:stack_trace_with_query".into(), 0.9);
+    }
+
+    // sqli:information_schema_leak
+    if body_lower.contains("information_schema") || body_lower.contains("table_schema") {
+        features.insert("sqli:information_schema_leak".into(), 0.95);
+    }
+
+    // sqli:table_names_leaked - look for common system table patterns
+    if body_lower.contains("table_name") && body_lower.contains("table_schema") {
+        features.insert("sqli:table_names_leaked".into(), 0.9);
+    }
+
+    // Time-based detection
+    // sqli:time_delay_detected, sqli:time_delay_proportional
+    if let Some(injected_delay) = ctx.injected_delay {
+        let actual_delay_s = (ctx.response.response_time_ms as f64) / 1000.0;
+        let baseline_s = (ctx.baseline.response_time_ms as f64) / 1000.0;
+        let extra_delay = actual_delay_s - baseline_s;
+
+        if extra_delay > (injected_delay * 0.7) {
+            features.insert(
+                "sqli:time_delay_detected".into(),
+                (extra_delay / injected_delay).min(1.0),
+            );
+        }
+        if extra_delay > (injected_delay * 0.8) && extra_delay < (injected_delay * 1.5) {
+            features.insert("sqli:time_delay_proportional".into(), 0.95);
+        }
+    }
+
+    // Boolean-based detection
+    if ctx.response.status == ctx.baseline.status {
+        let body_diff = body.len() as f64 - ctx.baseline.body.len() as f64;
+        if body_diff.abs() > 50.0 {
+            // sqli:boolean_content_length_delta
+            features.insert(
+                "sqli:boolean_content_length_delta".into(),
+                (body_diff.abs() / ctx.baseline.body.len().max(1) as f64).min(1.0),
+            );
+        }
+    } else {
+        features.insert("sqli:boolean_status_code_diff".into(), 1.0);
+    }
+
+    // Input characteristics
+    // sqli:single_quote_triggers_error
+    if ctx.probe_payload.contains('\'')
+        && ctx.response.status >= 400
+        && ctx.baseline.status < 400
+    {
+        features.insert("sqli:single_quote_triggers_error".into(), 1.0);
+    }
+
+    // False positive suppression
+    // sqli:waf_blocked_response
+    if ctx.response.status == 403
+        || ctx.response.status == 406
+        || body_lower.contains("blocked")
+        || body_lower.contains("waf")
+        || body_lower.contains("firewall")
+        || body_lower.contains("mod_security")
+    {
+        features.insert("sqli:waf_blocked_response".into(), 1.0);
+    }
+
+    // sqli:error_in_unrelated_context - error exists in baseline too
+    if ctx.baseline.status >= 500 && ctx.response.status >= 500 {
+        features.insert("sqli:error_in_unrelated_context".into(), 1.0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::*;
+    use super::*;
+
+    #[test]
+    fn test_mysql_error_detection() {
+        let response = make_response(
+            "You have an error in your SQL syntax near '1' at line 1",
+            500,
+        );
+        let ctx = make_ctx("sqli", "'", response);
+        let mut features = HashMap::new();
+        extract_sqli_features(&ctx, &mut features);
+
+        assert!(features.contains_key("sqli:error_mysql_syntax"));
+        assert!(*features.get("sqli:error_mysql_syntax").unwrap() > 0.9);
+    }
+
+    #[test]
+    fn test_postgresql_error_detection() {
+        let response = make_response(
+            "ERROR: syntax error at or near \"'\" LINE 1: SELECT * FROM users WHERE id = ''",
+            500,
+        );
+        let ctx = make_ctx("sqli", "'", response);
+        let mut features = HashMap::new();
+        extract_sqli_features(&ctx, &mut features);
+
+        assert!(features.contains_key("sqli:error_postgresql_syntax"));
+    }
+
+    #[test]
+    fn test_time_based_detection() {
+        let mut response = make_response("OK", 200);
+        response.response_time_ms = 5200; // ~5.2 seconds
+        let mut ctx = make_ctx("sqli", "1' AND SLEEP(5)--", response);
+        ctx.injected_delay = Some(5.0);
+        ctx.baseline.response_time_ms = 100;
+
+        let mut features = HashMap::new();
+        extract_sqli_features(&ctx, &mut features);
+
+        assert!(features.contains_key("sqli:time_delay_detected"));
+        assert!(features.contains_key("sqli:time_delay_proportional"));
+    }
+
+    #[test]
+    fn test_waf_detection() {
+        let response = make_response("Request blocked by firewall", 403);
+        let ctx = make_ctx("sqli", "' OR 1=1--", response);
+        let mut features = HashMap::new();
+        extract_sqli_features(&ctx, &mut features);
+
+        assert!(features.contains_key("sqli:waf_blocked_response"));
+    }
+
+    #[test]
+    fn test_single_quote_error() {
+        let response = make_response("Internal Server Error", 500);
+        let ctx = make_ctx("sqli", "'", response);
+        let mut features = HashMap::new();
+        extract_sqli_features(&ctx, &mut features);
+
+        assert!(features.contains_key("sqli:single_quote_triggers_error"));
+    }
+
+    #[test]
+    fn test_information_schema_leak() {
+        let response = make_response(
+            "table_name: users, table_schema: public, information_schema",
+            200,
+        );
+        let ctx = make_ctx("sqli", "' UNION SELECT table_name FROM information_schema.tables--", response);
+        let mut features = HashMap::new();
+        extract_sqli_features(&ctx, &mut features);
+
+        assert!(features.contains_key("sqli:information_schema_leak"));
+        assert!(features.contains_key("sqli:table_names_leaked"));
+    }
+
+    #[test]
+    fn test_baseline_error_suppression() {
+        let mut response = make_response("Internal Server Error", 500);
+        response.status = 500;
+        let mut ctx = make_ctx("sqli", "'", response);
+        ctx.baseline.status = 500;
+
+        let mut features = HashMap::new();
+        extract_sqli_features(&ctx, &mut features);
+
+        assert!(features.contains_key("sqli:error_in_unrelated_context"));
+    }
+}

--- a/src/features/ssti.rs
+++ b/src/features/ssti.rs
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Bountyy Oy. All rights reserved.
+// This software is proprietary and confidential.
+
+use super::ProbeContext;
+use std::collections::HashMap;
+
+/// Extract SSTI (Server-Side Template Injection) features from a probe response
+pub fn extract_ssti_features(ctx: &ProbeContext, features: &mut HashMap<String, f64>) {
+    let body = &ctx.response.body;
+
+    // Math expression evaluation - the core SSTI signal
+    let math_probes: &[(&str, &str)] = &[
+        ("{{7*7}}", "49"),
+        ("{{7*'7'}}", "7777777"),   // Twig-specific
+        ("${7*7}", "49"),            // FreeMarker/Mako
+        ("<%= 7*7 %>", "49"),        // ERB
+        ("#{7*7}", "49"),            // Ruby interpolation
+    ];
+
+    for (probe, expected) in math_probes {
+        if ctx.probe_payload.contains(probe)
+            && body.contains(expected)
+            && !ctx.baseline.body.contains(expected)
+        {
+            features.insert("ssti:math_expression_evaluated".into(), 1.0);
+
+            // Identify specific engine
+            match *probe {
+                "{{7*7}}" => {
+                    features.insert("ssti:jinja2_expression_eval".into(), 0.9);
+                    features.insert("ssti:pebble_expression_eval".into(), 0.7);
+                    features.insert("ssti:nunjucks_expression_eval".into(), 0.7);
+                }
+                "{{7*'7'}}" => {
+                    features.insert("ssti:twig_expression_eval".into(), 0.95);
+                }
+                "${7*7}" => {
+                    features.insert("ssti:freemarker_expression_eval".into(), 0.8);
+                    features.insert("ssti:mako_expression_eval".into(), 0.8);
+                }
+                "<%= 7*7 %>" => {
+                    features.insert("ssti:erb_expression_eval".into(), 0.9);
+                    features.insert("ssti:ejs_expression_eval".into(), 0.8);
+                }
+                _ => {}
+            }
+            break;
+        }
+    }
+
+    // Error-based engine detection
+    let engine_errors: &[(&str, &str)] = &[
+        ("jinja2", "ssti:jinja2_expression_eval"),
+        ("twig", "ssti:twig_expression_eval"),
+        ("freemarker", "ssti:freemarker_expression_eval"),
+        ("velocity", "ssti:velocity_expression_eval"),
+        ("thymeleaf", "ssti:thymeleaf_expression_eval"),
+        ("smarty", "ssti:smarty_expression_eval"),
+        ("mako", "ssti:mako_expression_eval"),
+    ];
+
+    let body_lower = body.to_lowercase();
+    let baseline_lower = ctx.baseline.body.to_lowercase();
+    for (engine, feature_key) in engine_errors {
+        if body_lower.contains(engine) && !baseline_lower.contains(engine) {
+            features.insert("ssti:error_reveals_engine".into(), 1.0);
+            features.insert(feature_key.to_string(), 0.7);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::*;
+    use super::*;
+
+    #[test]
+    fn test_jinja2_math_eval() {
+        let response = make_response("Result: 49", 200);
+        let ctx = make_ctx("ssti", "{{7*7}}", response);
+        let mut features = HashMap::new();
+        extract_ssti_features(&ctx, &mut features);
+
+        assert!(features.contains_key("ssti:math_expression_evaluated"));
+        assert!(features.contains_key("ssti:jinja2_expression_eval"));
+    }
+
+    #[test]
+    fn test_twig_specific() {
+        let response = make_response("Output: 7777777", 200);
+        let ctx = make_ctx("ssti", "{{7*'7'}}", response);
+        let mut features = HashMap::new();
+        extract_ssti_features(&ctx, &mut features);
+
+        assert!(features.contains_key("ssti:math_expression_evaluated"));
+        assert!(features.contains_key("ssti:twig_expression_eval"));
+    }
+
+    #[test]
+    fn test_no_eval_no_features() {
+        let response = make_response("No template evaluation here", 200);
+        let ctx = make_ctx("ssti", "{{7*7}}", response);
+        let mut features = HashMap::new();
+        extract_ssti_features(&ctx, &mut features);
+
+        assert!(!features.contains_key("ssti:math_expression_evaluated"));
+    }
+
+    #[test]
+    fn test_baseline_already_has_value() {
+        let response = make_response("The answer is 49", 200);
+        let mut ctx = make_ctx("ssti", "{{7*7}}", response);
+        ctx.baseline = make_response("The answer is 49", 200);
+        let mut features = HashMap::new();
+        extract_ssti_features(&ctx, &mut features);
+
+        // Should NOT trigger because baseline already has "49"
+        assert!(!features.contains_key("ssti:math_expression_evaluated"));
+    }
+
+    #[test]
+    fn test_engine_error_detection() {
+        let response = make_response(
+            "jinja2.exceptions.UndefinedError: 'foo' is undefined",
+            500,
+        );
+        let ctx = make_ctx("ssti", "{{foo}}", response);
+        let mut features = HashMap::new();
+        extract_ssti_features(&ctx, &mut features);
+
+        assert!(features.contains_key("ssti:error_reveals_engine"));
+        assert!(features.contains_key("ssti:jinja2_expression_eval"));
+    }
+
+    #[test]
+    fn test_erb_eval() {
+        let response = make_response("Value: 49", 200);
+        let ctx = make_ctx("ssti", "<%= 7*7 %>", response);
+        let mut features = HashMap::new();
+        extract_ssti_features(&ctx, &mut features);
+
+        assert!(features.contains_key("ssti:math_expression_evaluated"));
+        assert!(features.contains_key("ssti:erb_expression_eval"));
+    }
+}

--- a/src/features/traversal.rs
+++ b/src/features/traversal.rs
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Bountyy Oy. All rights reserved.
+// This software is proprietary and confidential.
+
+use super::ProbeContext;
+use std::collections::HashMap;
+
+/// Extract Path Traversal features from a probe response
+pub fn extract_traversal_features(ctx: &ProbeContext, features: &mut HashMap<String, f64>) {
+    let body = &ctx.response.body;
+
+    // traversal:etc_passwd_content - Linux passwd file content
+    if body.contains("root:x:0:0") || body.contains("root:*:0:0") {
+        features.insert("traversal:etc_passwd_content".into(), 1.0);
+    }
+
+    // traversal:etc_shadow_content
+    if body.contains("root:$") || body.contains("root:!") {
+        features.insert("traversal:etc_shadow_content".into(), 1.0);
+    }
+
+    // traversal:windows_system_file
+    if body.contains("[boot loader]")    // boot.ini
+        || body.contains("[operating systems]")
+        || body.contains("[extensions]") // win.ini
+    {
+        features.insert("traversal:windows_system_file".into(), 1.0);
+    }
+
+    // traversal:known_config_file - application config files
+    let config_patterns = [
+        "DB_PASSWORD",
+        "DATABASE_URL",
+        "SECRET_KEY",
+        "AWS_SECRET",
+        "PRIVATE_KEY",
+        "-----BEGIN",
+        "<?php",
+        "<?xml version",
+    ];
+    for pattern in &config_patterns {
+        if body.contains(pattern) && !ctx.baseline.body.contains(pattern) {
+            features.insert("traversal:known_config_file".into(), 0.9);
+            break;
+        }
+    }
+
+    // traversal:directory_listing
+    if (body.contains("Index of /") || body.contains("Directory listing"))
+        && !ctx.baseline.body.contains("Index of /")
+    {
+        features.insert("traversal:directory_listing".into(), 0.85);
+    }
+
+    // traversal:path_in_error - path disclosed in error message
+    let path_patterns = ["/var/www", "/home/", "/usr/", "/opt/", "C:\\", "D:\\"];
+    for pattern in &path_patterns {
+        if body.contains(pattern) && !ctx.baseline.body.contains(pattern) {
+            features.insert("traversal:path_in_error".into(), 0.8);
+            break;
+        }
+    }
+
+    // traversal:null_byte_bypass
+    if ctx.probe_payload.contains("%00") || ctx.probe_payload.contains('\0') {
+        if ctx.response.status == 200 && ctx.response.body_bytes != ctx.baseline.body_bytes {
+            features.insert("traversal:null_byte_bypass".into(), 0.9);
+        }
+    }
+
+    // traversal:waf_blocked
+    if ctx.response.status == 403
+        || ctx.response.body.to_lowercase().contains("blocked")
+        || ctx.response.body.to_lowercase().contains("waf")
+    {
+        features.insert("traversal:waf_blocked".into(), 1.0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::*;
+    use super::*;
+
+    #[test]
+    fn test_etc_passwd_traversal() {
+        let response = make_response(
+            "root:x:0:0:root:/root:/bin/bash\ndaemon:x:1:1:",
+            200,
+        );
+        let ctx = make_ctx("traversal", "../../../../etc/passwd", response);
+        let mut features = HashMap::new();
+        extract_traversal_features(&ctx, &mut features);
+
+        assert!(features.contains_key("traversal:etc_passwd_content"));
+    }
+
+    #[test]
+    fn test_config_file_leak() {
+        let response = make_response(
+            "DB_PASSWORD=secretpass123\nDATABASE_URL=postgres://...",
+            200,
+        );
+        let ctx = make_ctx("traversal", "../../../../.env", response);
+        let mut features = HashMap::new();
+        extract_traversal_features(&ctx, &mut features);
+
+        assert!(features.contains_key("traversal:known_config_file"));
+    }
+
+    #[test]
+    fn test_windows_system_file() {
+        let response = make_response(
+            "[boot loader]\ntimeout=30\n[operating systems]",
+            200,
+        );
+        let ctx = make_ctx("traversal", "..\\..\\boot.ini", response);
+        let mut features = HashMap::new();
+        extract_traversal_features(&ctx, &mut features);
+
+        assert!(features.contains_key("traversal:windows_system_file"));
+    }
+}

--- a/src/features/xss.rs
+++ b/src/features/xss.rs
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 Bountyy Oy. All rights reserved.
+// This software is proprietary and confidential.
+
+use super::ProbeContext;
+use std::collections::HashMap;
+
+/// Extract XSS features from a probe response
+pub fn extract_xss_features(ctx: &ProbeContext, features: &mut HashMap<String, f64>) {
+    let body = &ctx.response.body;
+    let body_lower = body.to_lowercase();
+    let probe = &ctx.probe_payload;
+
+    // Check if probe payload is reflected in response
+    let reflected = body.contains(probe);
+    let reflected_lower = body_lower.contains(&probe.to_lowercase());
+
+    if !reflected && !reflected_lower {
+        return; // No reflection, no XSS features to extract
+    }
+
+    // xss:reflection_unencoded - exact payload reflected
+    if reflected {
+        features.insert("xss:reflection_unencoded".into(), 1.0);
+    }
+
+    // xss:script_tag_reflected
+    if body_lower.contains("<script") && reflected {
+        features.insert("xss:script_tag_reflected".into(), 0.95);
+    }
+
+    // xss:event_handler_reflected
+    for handler in &[
+        "onerror=",
+        "onload=",
+        "onclick=",
+        "onmouseover=",
+        "onfocus=",
+    ] {
+        if body_lower.contains(handler) && reflected {
+            features.insert("xss:event_handler_reflected".into(), 0.95);
+            break;
+        }
+    }
+
+    // xss:javascript_uri_reflected
+    if body_lower.contains("javascript:") && reflected {
+        features.insert("xss:javascript_uri_reflected".into(), 0.9);
+    }
+
+    // Context detection - WHERE is it reflected?
+    if let Some(pos) = body.find(probe) {
+        let before = &body[..pos];
+
+        // xss:reflection_in_script_block
+        let in_script = before.rfind("<script").map_or(false, |script_pos| {
+            !before[script_pos..].contains("</script>")
+        });
+        if in_script {
+            features.insert("xss:reflection_in_script_block".into(), 1.0);
+        }
+
+        // xss:reflection_in_attribute - check if inside an HTML attribute
+        let in_attr = before.rfind('=').map_or(false, |eq_pos| {
+            let after_eq = &before[eq_pos..];
+            (after_eq.contains('"') && after_eq.matches('"').count() % 2 == 1)
+                || (after_eq.contains('\'') && after_eq.matches('\'').count() % 2 == 1)
+        });
+        if in_attr {
+            features.insert("xss:reflection_in_attribute".into(), 1.0);
+        }
+
+        // xss:reflection_in_html_body - default if not in special context
+        if !in_script && !in_attr {
+            features.insert("xss:reflection_in_html_body".into(), 1.0);
+        }
+    }
+
+    // CSP analysis - check response headers
+    if !ctx.response.headers.contains_key("content-security-policy") {
+        // xss:no_csp_header
+        features.insert("xss:no_csp_header".into(), 1.0);
+    } else if let Some(csp) = ctx.response.headers.get("content-security-policy") {
+        if csp.contains("unsafe-inline") {
+            features.insert("xss:csp_allows_unsafe_inline".into(), 1.0);
+        }
+        if csp.contains("unsafe-eval") {
+            features.insert("xss:csp_allows_unsafe_eval".into(), 1.0);
+        }
+        // Strict CSP suppresses XSS confidence
+        if !csp.contains("unsafe-inline") && !csp.contains("unsafe-eval") {
+            features.insert("xss:csp_blocks_execution".into(), 1.0);
+        }
+    }
+
+    // xss:content_type_not_html - false positive suppressor
+    if let Some(ct) = ctx.response.headers.get("content-type") {
+        if !ct.contains("text/html") && !ct.contains("application/xhtml") {
+            features.insert("xss:content_type_not_html".into(), 1.0);
+        }
+    }
+
+    // xss:httponly_cookie_set
+    if let Some(cookie) = ctx.response.headers.get("set-cookie") {
+        if cookie.to_lowercase().contains("httponly") {
+            features.insert("xss:httponly_cookie_set".into(), 1.0);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::*;
+    use super::*;
+
+    #[test]
+    fn test_reflected_xss_basic() {
+        let response = make_response(
+            "<html><body><script>alert(1)</script></body></html>",
+            200,
+        );
+        let ctx = make_ctx("xss", "<script>alert(1)</script>", response);
+        let mut features = HashMap::new();
+        extract_xss_features(&ctx, &mut features);
+
+        assert!(features.contains_key("xss:reflection_unencoded"));
+        assert!(features.contains_key("xss:script_tag_reflected"));
+    }
+
+    #[test]
+    fn test_no_reflection_no_features() {
+        let response = make_response("<html><body>Safe content</body></html>", 200);
+        let ctx = make_ctx("xss", "<script>alert(1)</script>", response);
+        let mut features = HashMap::new();
+        extract_xss_features(&ctx, &mut features);
+
+        assert!(features.is_empty());
+    }
+
+    #[test]
+    fn test_event_handler_detection() {
+        let response = make_response(
+            "<img src=x onerror=alert(1)>",
+            200,
+        );
+        let ctx = make_ctx("xss", "<img src=x onerror=alert(1)>", response);
+        let mut features = HashMap::new();
+        extract_xss_features(&ctx, &mut features);
+
+        assert!(features.contains_key("xss:event_handler_reflected"));
+    }
+
+    #[test]
+    fn test_no_csp_header() {
+        let response = make_response("<script>alert(1)</script>", 200);
+        let ctx = make_ctx("xss", "<script>alert(1)</script>", response);
+        let mut features = HashMap::new();
+        extract_xss_features(&ctx, &mut features);
+
+        assert!(features.contains_key("xss:no_csp_header"));
+    }
+
+    #[test]
+    fn test_strict_csp_suppression() {
+        let mut response = make_response("<script>alert(1)</script>", 200);
+        response.headers.insert(
+            "content-security-policy".to_string(),
+            "default-src 'self'; script-src 'self'".to_string(),
+        );
+        let ctx = make_ctx("xss", "<script>alert(1)</script>", response);
+        let mut features = HashMap::new();
+        extract_xss_features(&ctx, &mut features);
+
+        assert!(features.contains_key("xss:csp_blocks_execution"));
+        assert!(!features.contains_key("xss:no_csp_header"));
+    }
+
+    #[test]
+    fn test_unsafe_inline_csp() {
+        let mut response = make_response("<script>alert(1)</script>", 200);
+        response.headers.insert(
+            "content-security-policy".to_string(),
+            "default-src 'self'; script-src 'unsafe-inline'".to_string(),
+        );
+        let ctx = make_ctx("xss", "<script>alert(1)</script>", response);
+        let mut features = HashMap::new();
+        extract_xss_features(&ctx, &mut features);
+
+        assert!(features.contains_key("xss:csp_allows_unsafe_inline"));
+    }
+
+    #[test]
+    fn test_reflection_in_script_block() {
+        let response = make_response(
+            "<html><script>var x = 'PAYLOAD';</script></html>",
+            200,
+        );
+        let ctx = make_ctx("xss", "PAYLOAD", response);
+        let mut features = HashMap::new();
+        extract_xss_features(&ctx, &mut features);
+
+        assert!(features.contains_key("xss:reflection_in_script_block"));
+    }
+
+    #[test]
+    fn test_content_type_not_html() {
+        let mut response = make_response("{\"value\": \"<script>alert(1)</script>\"}", 200);
+        response.headers.insert(
+            "content-type".to_string(),
+            "application/json".to_string(),
+        );
+        let ctx = make_ctx("xss", "<script>alert(1)</script>", response);
+        let mut features = HashMap::new();
+        extract_xss_features(&ctx, &mut features);
+
+        assert!(features.contains_key("xss:content_type_not_html"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,8 +80,17 @@ pub mod signing;
 // Module IDs for server-side authorization
 pub mod modules;
 
-// Machine Learning module (federated learning, GDPR-compliant)
+// Machine Learning module (model-based detection, GDPR-compliant)
 pub mod ml;
+
+// Feature extraction layer for model-based vulnerability scoring
+pub mod features;
+
+// Model scorer for vulnerability detection
+pub mod scorer;
+
+// Probe payload library
+pub mod probes;
 
 // GraphQL introspection and schema parsing
 pub mod graphql_introspection;

--- a/src/ml/federated.rs
+++ b/src/ml/federated.rs
@@ -2,15 +2,14 @@
 // This software is proprietary and confidential.
 
 /**
- * Bountyy Oy - Federated Learning
- * Privacy-preserving model training where only model weights are shared
+ * Bountyy Oy - Model Distribution Client
+ * One-way model distribution: download detection model from server
  *
  * How it works:
- * 1. Each user trains locally on their own verified vulnerability data
- * 2. Only model WEIGHTS are sent to the aggregation server (no raw data)
- * 3. Server aggregates weights from all users using Federated Averaging
- * 4. Updated global model is distributed back to all users
- * 5. All users benefit from collective learning while data stays private
+ * 1. Server trains and aggregates the detection model
+ * 2. CLI downloads the latest model (requires valid license)
+ * 3. Model weights are applied locally for vulnerability scoring
+ * 4. Downloaded model is cached locally for offline use
  *
  * @copyright 2026 Bountyy Oy
  * @license Proprietary
@@ -22,7 +21,7 @@ use std::fs;
 use std::path::PathBuf;
 use tracing::{debug, info, warn};
 
-/// Model weights that can be safely shared (no raw data)
+/// Model weights used for vulnerability scoring
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelWeights {
     /// Unique identifier for this model version
@@ -102,76 +101,6 @@ impl ModelWeights {
     }
 }
 
-/// Contribution package sent to aggregation server
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct WeightContribution {
-    /// Anonymous client ID (not linked to user identity)
-    pub client_id: String,
-    /// The model weights being contributed
-    pub weights: ModelWeights,
-    /// Differential privacy noise already applied
-    pub dp_noise_applied: bool,
-    /// Signature for authenticity (prevents tampering)
-    pub signature: String,
-}
-
-impl WeightContribution {
-    /// Create a new contribution with differential privacy
-    pub fn new(weights: ModelWeights, client_id: &str) -> Self {
-        let mut contribution = Self {
-            client_id: client_id.to_string(),
-            weights,
-            dp_noise_applied: false,
-            signature: String::new(),
-        };
-
-        // Apply differential privacy noise
-        contribution.apply_differential_privacy();
-        contribution.sign();
-
-        contribution
-    }
-
-    /// Apply differential privacy noise to weights
-    /// This prevents any single training example from being reconstructed
-    fn apply_differential_privacy(&mut self) {
-        use rand::Rng;
-        let mut rng = rand::thread_rng();
-
-        // Laplace noise with epsilon = 1.0 (standard privacy guarantee)
-        let epsilon = 1.0;
-        let sensitivity = 0.1; // Max impact of single example
-        let scale = sensitivity / epsilon;
-
-        for weight in self.weights.weights.values_mut() {
-            // Add Laplace noise
-            let u: f64 = rng.gen_range(-0.5..0.5);
-            let noise = -scale * u.signum() * (1.0 - 2.0 * u.abs()).ln();
-            *weight += noise;
-        }
-
-        // Also add noise to bias
-        let u: f64 = rng.gen_range(-0.5..0.5);
-        let noise = -scale * u.signum() * (1.0 - 2.0 * u.abs()).ln();
-        self.weights.bias += noise;
-
-        self.dp_noise_applied = true;
-    }
-
-    /// Sign the contribution for authenticity
-    fn sign(&mut self) {
-        use std::hash::{Hash, Hasher};
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-
-        // Hash key components
-        self.client_id.hash(&mut hasher);
-        self.weights.model_id.hash(&mut hasher);
-        self.weights.timestamp.hash(&mut hasher);
-
-        self.signature = format!("{:x}", hasher.finish());
-    }
-}
-
 /// Aggregated model from the server
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AggregatedModel {
@@ -187,36 +116,40 @@ pub struct AggregatedModel {
     pub server_signature: String,
 }
 
-/// Federated learning client
+/// Detection model category information
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelCategory {
+    pub name: String,
+    pub feature_count: usize,
+    pub description: Option<String>,
+}
+
+/// Model distribution client (download-only, no contribution)
 pub struct FederatedClient {
-    /// Anonymous client ID (persisted locally)
-    client_id: String,
-    /// Path to client ID storage
-    client_id_path: PathBuf,
-    /// API endpoint for federated server
+    /// API endpoint for model server
     server_url: String,
-    /// Current local model weights
-    local_weights: Option<ModelWeights>,
     /// Latest fetched global model
     global_model: Option<AggregatedModel>,
+    /// License key for authenticated model downloads
+    license_key: Option<String>,
 }
 
 impl FederatedClient {
-    /// Create new federated client
+    /// Create new model distribution client
     pub fn new() -> Result<Self> {
         let data_dir = Self::get_data_dir()?;
         fs::create_dir_all(&data_dir)?;
 
-        let client_id_path = data_dir.join("client_id");
-        let client_id = Self::get_or_create_client_id(&client_id_path)?;
-
         Ok(Self {
-            client_id,
-            client_id_path,
             server_url: "https://lonkero.bountyy.fi/api/federated/v1".to_string(),
-            local_weights: None,
             global_model: None,
+            license_key: None,
         })
+    }
+
+    /// Set the license key for authenticated model downloads
+    pub fn set_license_key(&mut self, key: String) {
+        self.license_key = Some(key);
     }
 
     /// Get data directory
@@ -225,106 +158,33 @@ impl FederatedClient {
         Ok(home.join(".lonkero").join("federated"))
     }
 
-    /// Get or create anonymous client ID
-    fn get_or_create_client_id(path: &PathBuf) -> Result<String> {
-        if path.exists() {
-            Ok(fs::read_to_string(path)?.trim().to_string())
-        } else {
-            let id = uuid::Uuid::new_v4().to_string();
-            fs::write(path, &id)?;
-            Ok(id)
-        }
-    }
-
-    /// Set local model weights (from local training)
-    pub fn set_local_weights(&mut self, weights: ModelWeights) {
-        self.local_weights = Some(weights);
-    }
-
-    /// Check if we have enough data to contribute
-    pub fn can_contribute(&self) -> bool {
-        self.local_weights
-            .as_ref()
-            .map(|w| w.training_count >= 50) // Minimum examples to contribute
-            .unwrap_or(false)
-    }
-
-    /// Contribute local weights to the federated network
-    pub async fn contribute_weights(&self) -> Result<bool> {
-        let weights = self
-            .local_weights
-            .as_ref()
-            .context("No local weights to contribute")?;
-
-        if weights.training_count < 50 {
-            info!(
-                "Not enough training data to contribute (need 50, have {})",
-                weights.training_count
-            );
-            return Ok(false);
-        }
-
-        let contribution = WeightContribution::new(weights.clone(), &self.client_id);
-
-        info!("Contributing weights to federated network...");
-        debug!(
-            "Contribution: {} weights, {} training examples",
-            contribution.weights.weights.len(),
-            contribution.weights.training_count
-        );
-
-        // Send to server
-        let client = reqwest::Client::new();
-        let response = client
-            .post(format!("{}/contribute", self.server_url))
-            .json(&contribution)
-            .timeout(std::time::Duration::from_secs(30))
-            .send()
-            .await;
-
-        match response {
-            Ok(resp) if resp.status().is_success() => {
-                info!("Successfully contributed weights to federated network");
-                Ok(true)
-            }
-            Ok(resp) => {
-                warn!("Server rejected contribution: {}", resp.status());
-                Ok(false)
-            }
-            Err(e) => {
-                // Offline mode - save for later
-                debug!(
-                    "Could not reach server, saving contribution for later: {}",
-                    e
-                );
-                self.save_pending_contribution(&contribution)?;
-                Ok(false)
-            }
-        }
-    }
-
-    /// Fetch latest global model from server
+    /// Fetch latest global model from server (requires license key)
     pub async fn fetch_global_model(&mut self) -> Result<Option<AggregatedModel>> {
-        info!("Fetching global model from federated network...");
+        info!("Fetching detection model from server...");
 
         let client = reqwest::Client::new();
-        let response = client
+        let mut request = client
             .get(format!("{}/model/latest", self.server_url))
-            .timeout(std::time::Duration::from_secs(30))
-            .send()
-            .await;
+            .timeout(std::time::Duration::from_secs(30));
+
+        // Add license key header for authentication
+        if let Some(ref key) = self.license_key {
+            request = request.header("X-License-Key", key);
+        }
+
+        let response = request.send().await;
 
         match response {
             Ok(resp) if resp.status().is_success() => {
                 let model: AggregatedModel = resp.json().await?;
                 info!(
-                    "Fetched global model v{} ({} contributors, {} examples)",
+                    "Fetched detection model v{} ({} contributors, {} examples)",
                     model.global_version, model.contributor_count, model.total_training_examples
                 );
 
                 // Verify compatibility
                 if !model.weights.is_compatible() {
-                    warn!("Global model has incompatible schema, skipping");
+                    warn!("Detection model has incompatible schema, skipping");
                     return Ok(None);
                 }
 
@@ -332,8 +192,13 @@ impl FederatedClient {
                 self.save_global_model(&model)?;
                 Ok(Some(model))
             }
+            Ok(resp) if resp.status().as_u16() == 401 => {
+                warn!("Valid license required to download detection model");
+                // Try loading cached model as fallback
+                Ok(self.load_cached_global_model()?)
+            }
             Ok(resp) => {
-                debug!("No global model available: {}", resp.status());
+                debug!("No detection model available: {}", resp.status());
                 // Try loading cached model
                 Ok(self.load_cached_global_model()?)
             }
@@ -345,116 +210,35 @@ impl FederatedClient {
         }
     }
 
-    /// Merge global model with local model
-    /// Uses weighted average based on training counts
-    pub fn merge_models(&mut self) -> Result<ModelWeights> {
-        let local = self.local_weights.as_ref();
-        let global = self.global_model.as_ref();
-
-        match (local, global) {
-            (Some(local), Some(global)) => {
-                info!(
-                    "Merging local model ({} examples) with global model ({} examples)",
-                    local.training_count, global.total_training_examples
-                );
-
-                // Weighted average based on training counts
-                let local_weight = local.training_count as f64;
-                let global_weight = global.total_training_examples as f64;
-                let total_weight = local_weight + global_weight;
-
-                let mut merged_weights = HashMap::new();
-
-                // Merge each weight
-                for (key, &local_val) in &local.weights {
-                    let global_val = global.weights.weights.get(key).copied().unwrap_or(0.0);
-                    let merged =
-                        (local_val * local_weight + global_val * global_weight) / total_weight;
-                    merged_weights.insert(key.clone(), merged);
-                }
-
-                // Include any global-only weights
-                for (key, &global_val) in &global.weights.weights {
-                    if !merged_weights.contains_key(key) {
-                        let merged = global_val * global_weight / total_weight;
-                        merged_weights.insert(key.clone(), merged);
-                    }
-                }
-
-                // Merge bias
-                let merged_bias = (local.bias * local_weight + global.weights.bias * global_weight)
-                    / total_weight;
-
-                Ok(ModelWeights::new(
-                    merged_weights,
-                    merged_bias,
-                    local.training_count + global.total_training_examples,
-                ))
-            }
-            (Some(local), None) => {
-                debug!("No global model available, using local only");
-                Ok(local.clone())
-            }
-            (None, Some(global)) => {
-                debug!("No local model, using global only");
-                Ok(global.weights.clone())
-            }
-            (None, None) => {
-                anyhow::bail!("No models available to merge")
-            }
-        }
-    }
-
-    /// Save pending contribution for later upload
-    fn save_pending_contribution(&self, contribution: &WeightContribution) -> Result<()> {
-        let pending_dir = Self::get_data_dir()?.join("pending");
-        fs::create_dir_all(&pending_dir)?;
-
-        let path = pending_dir.join(format!("{}.json", contribution.weights.model_id));
-        let json = serde_json::to_string_pretty(contribution)?;
-        fs::write(path, json)?;
-
-        debug!("Saved pending contribution for later upload");
-        Ok(())
-    }
-
-    /// Upload any pending contributions
-    pub async fn upload_pending(&self) -> Result<usize> {
-        let pending_dir = Self::get_data_dir()?.join("pending");
-        if !pending_dir.exists() {
-            return Ok(0);
-        }
-
-        let mut uploaded = 0;
+    /// Fetch available detection categories (public, no auth required)
+    pub async fn fetch_categories(&self) -> Result<Vec<ModelCategory>> {
         let client = reqwest::Client::new();
+        let response = client
+            .get(format!("{}/model/categories", self.server_url))
+            .timeout(std::time::Duration::from_secs(30))
+            .send()
+            .await;
 
-        for entry in fs::read_dir(&pending_dir)? {
-            let entry = entry?;
-            let path = entry.path();
-
-            if path.extension().map(|e| e == "json").unwrap_or(false) {
-                let content = fs::read_to_string(&path)?;
-                let contribution: WeightContribution = serde_json::from_str(&content)?;
-
-                let response = client
-                    .post(format!("{}/contribute", self.server_url))
-                    .json(&contribution)
-                    .timeout(std::time::Duration::from_secs(30))
-                    .send()
-                    .await;
-
-                if response.is_ok() && response.unwrap().status().is_success() {
-                    fs::remove_file(&path)?;
-                    uploaded += 1;
-                }
+        match response {
+            Ok(resp) if resp.status().is_success() => {
+                let categories: Vec<ModelCategory> = resp.json().await?;
+                info!("Fetched {} detection categories", categories.len());
+                Ok(categories)
+            }
+            Ok(resp) => {
+                debug!("Could not fetch categories: {}", resp.status());
+                Ok(Vec::new())
+            }
+            Err(e) => {
+                debug!("Could not reach server for categories: {}", e);
+                Ok(Vec::new())
             }
         }
+    }
 
-        if uploaded > 0 {
-            info!("Uploaded {} pending contributions", uploaded);
-        }
-
-        Ok(uploaded)
+    /// Get the current global model (if any)
+    pub fn get_model(&self) -> Option<&AggregatedModel> {
+        self.global_model.as_ref()
     }
 
     /// Save global model to cache
@@ -471,7 +255,7 @@ impl FederatedClient {
         if path.exists() {
             let content = fs::read_to_string(path)?;
             let model: AggregatedModel = serde_json::from_str(&content)?;
-            debug!("Loaded cached global model v{}", model.global_version);
+            debug!("Loaded cached detection model v{}", model.global_version);
             Ok(Some(model))
         } else {
             Ok(None)
@@ -481,158 +265,30 @@ impl FederatedClient {
     /// Get client statistics
     pub fn get_stats(&self) -> FederatedStats {
         FederatedStats {
-            client_id: self.client_id.clone(),
-            has_local_model: self.local_weights.is_some(),
-            local_training_count: self
-                .local_weights
-                .as_ref()
-                .map(|w| w.training_count)
-                .unwrap_or(0),
             has_global_model: self.global_model.is_some(),
             global_version: self.global_model.as_ref().map(|m| m.global_version),
             global_contributors: self.global_model.as_ref().map(|m| m.contributor_count),
-            can_contribute: self.can_contribute(),
         }
     }
 }
 
 impl Default for FederatedClient {
     fn default() -> Self {
-        Self::new().expect("Failed to create federated client")
+        Self::new().expect("Failed to create model distribution client")
     }
 }
 
-/// Federated learning statistics
+/// Model distribution statistics
 #[derive(Debug)]
 pub struct FederatedStats {
-    pub client_id: String,
-    pub has_local_model: bool,
-    pub local_training_count: usize,
     pub has_global_model: bool,
     pub global_version: Option<u32>,
     pub global_contributors: Option<usize>,
-    pub can_contribute: bool,
-}
-
-/// Aggregation server (for reference - runs on Bountyy infrastructure)
-/// This shows how the server-side aggregation works
-pub struct AggregationServer {
-    /// All received contributions
-    contributions: Vec<WeightContribution>,
-    /// Current global model version
-    current_version: u32,
-}
-
-impl AggregationServer {
-    /// Create new aggregation server
-    pub fn new() -> Self {
-        Self {
-            contributions: Vec::new(),
-            current_version: 0,
-        }
-    }
-
-    /// Receive a contribution from a client
-    pub fn receive_contribution(&mut self, contribution: WeightContribution) -> Result<()> {
-        // Validate contribution
-        if !contribution.weights.is_compatible() {
-            anyhow::bail!("Incompatible weight schema");
-        }
-
-        if !contribution.dp_noise_applied {
-            anyhow::bail!("Contribution must have differential privacy applied");
-        }
-
-        // Check minimum training count
-        if contribution.weights.training_count < 50 {
-            anyhow::bail!("Insufficient training data");
-        }
-
-        self.contributions.push(contribution);
-        info!("Received contribution, total: {}", self.contributions.len());
-
-        Ok(())
-    }
-
-    /// Aggregate all contributions using Federated Averaging
-    pub fn aggregate(&mut self) -> Result<AggregatedModel> {
-        if self.contributions.is_empty() {
-            anyhow::bail!("No contributions to aggregate");
-        }
-
-        info!("Aggregating {} contributions", self.contributions.len());
-
-        // Calculate total training examples
-        let total_examples: usize = self
-            .contributions
-            .iter()
-            .map(|c| c.weights.training_count)
-            .sum();
-
-        // Federated Averaging: weighted sum by training count
-        let mut aggregated_weights: HashMap<String, f64> = HashMap::new();
-        let mut aggregated_bias = 0.0;
-
-        for contribution in &self.contributions {
-            let weight = contribution.weights.training_count as f64 / total_examples as f64;
-
-            for (key, &value) in &contribution.weights.weights {
-                *aggregated_weights.entry(key.clone()).or_insert(0.0) += value * weight;
-            }
-
-            aggregated_bias += contribution.weights.bias * weight;
-        }
-
-        self.current_version += 1;
-
-        let model = AggregatedModel {
-            global_version: self.current_version,
-            weights: ModelWeights::new(aggregated_weights, aggregated_bias, total_examples),
-            contributor_count: self.contributions.len(),
-            total_training_examples: total_examples,
-            server_signature: self.sign_model(),
-        };
-
-        // Clear contributions after aggregation
-        self.contributions.clear();
-
-        info!(
-            "Created global model v{} from {} contributors",
-            model.global_version, model.contributor_count
-        );
-
-        Ok(model)
-    }
-
-    /// Sign the aggregated model
-    fn sign_model(&self) -> String {
-        use std::hash::{Hash, Hasher};
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        self.current_version.hash(&mut hasher);
-        chrono::Utc::now().timestamp().hash(&mut hasher);
-        format!("bountyy-sig-{:x}", hasher.finish())
-    }
-}
-
-impl Default for AggregationServer {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_weight_contribution_has_dp_noise() {
-        let weights =
-            ModelWeights::new([("test".to_string(), 0.5)].into_iter().collect(), 0.1, 100);
-
-        let contribution = WeightContribution::new(weights, "test-client");
-        assert!(contribution.dp_noise_applied);
-        assert!(!contribution.signature.is_empty());
-    }
 
     #[test]
     fn test_schema_compatibility() {
@@ -641,30 +297,39 @@ mod tests {
     }
 
     #[test]
-    fn test_aggregation() {
-        let mut server = AggregationServer::new();
-
-        // Add two contributions
-        let w1 = ModelWeights::new(
+    fn test_model_weights_creation() {
+        let weights = ModelWeights::new(
             [("feature1".to_string(), 0.8)].into_iter().collect(),
-            0.1,
+            -0.42,
             100,
         );
-        let c1 = WeightContribution::new(w1, "client1");
-        server.receive_contribution(c1).unwrap();
+        assert_eq!(weights.bias, -0.42);
+        assert_eq!(weights.training_count, 100);
+        assert!(weights.weights.contains_key("feature1"));
+    }
 
-        let w2 = ModelWeights::new(
-            [("feature1".to_string(), 0.4)].into_iter().collect(),
-            0.2,
-            100,
-        );
-        let c2 = WeightContribution::new(w2, "client2");
-        server.receive_contribution(c2).unwrap();
+    #[test]
+    fn test_federated_client_creation() {
+        let client = FederatedClient::new();
+        assert!(client.is_ok());
+        let client = client.unwrap();
+        assert!(client.global_model.is_none());
+        assert!(client.license_key.is_none());
+    }
 
-        let aggregated = server.aggregate().unwrap();
+    #[test]
+    fn test_set_license_key() {
+        let mut client = FederatedClient::new().unwrap();
+        client.set_license_key("test-key-123".to_string());
+        assert_eq!(client.license_key.as_deref(), Some("test-key-123"));
+    }
 
-        assert_eq!(aggregated.contributor_count, 2);
-        assert_eq!(aggregated.total_training_examples, 200);
-        assert_eq!(aggregated.global_version, 1);
+    #[test]
+    fn test_stats_no_model() {
+        let client = FederatedClient::new().unwrap();
+        let stats = client.get_stats();
+        assert!(!stats.has_global_model);
+        assert!(stats.global_version.is_none());
+        assert!(stats.global_contributors.is_none());
     }
 }

--- a/src/ml/mod.rs
+++ b/src/ml/mod.rs
@@ -9,13 +9,13 @@ pub mod integration;
 pub mod privacy;
 /**
  * Bountyy Oy - Machine Learning Module
- * Federated learning for vulnerability detection with privacy-preserving model training
+ * Model-based vulnerability detection with local training
  *
  * Features:
  * - Local training data collection (no data leaves machine)
  * - False positive classifier
  * - Vulnerability prediction
- * - Federated model weight aggregation
+ * - Detection model download from server
  * - Smart payload selection
  *
  * @copyright 2026 Bountyy Oy
@@ -25,7 +25,7 @@ pub mod training_data;
 
 pub use auto_learning::{AutoLearner, AutoVerification, LearningStats};
 pub use features::{FeatureExtractor, VulnFeatures};
-pub use federated::{AggregationServer, FederatedClient, ModelWeights};
+pub use federated::{FederatedClient, ModelWeights};
 pub use fp_classifier::{FalsePositiveClassifier, Prediction};
 pub use integration::{MlIntegration, MlPipeline, MlPipelineStats};
 pub use privacy::{DataRetentionPolicy, GdprCompliance, PrivacyManager};

--- a/src/ml/training_data.rs
+++ b/src/ml/training_data.rs
@@ -411,19 +411,10 @@ impl TrainingDataCollector {
         })
     }
 
-    /// Export training data for federated learning (anonymized features only)
-    pub fn export_for_federated(&self) -> Result<FederatedTrainingData> {
+    /// Export training data as anonymized features for analysis
+    pub fn export_features(&self) -> Result<Vec<Vec<f32>>> {
         let examples = self.get_training_data()?;
-
-        let features: Vec<Vec<f32>> = examples.iter().map(|e| e.to_feature_vector()).collect();
-
-        let labels: Vec<f32> = examples.iter().filter_map(|e| e.get_label()).collect();
-
-        Ok(FederatedTrainingData {
-            features,
-            labels,
-            example_count: examples.len(),
-        })
+        Ok(examples.iter().map(|e| e.to_feature_vector()).collect())
     }
 }
 
@@ -454,13 +445,6 @@ impl TrainingStats {
     }
 }
 
-/// Anonymized training data for federated learning
-#[derive(Debug, Serialize, Deserialize)]
-pub struct FederatedTrainingData {
-    pub features: Vec<Vec<f32>>,
-    pub labels: Vec<f32>,
-    pub example_count: usize,
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/probes/mod.rs
+++ b/src/probes/mod.rs
@@ -1,0 +1,252 @@
+// Copyright (c) 2026 Bountyy Oy. All rights reserved.
+// This software is proprietary and confidential.
+
+/**
+ * Bountyy Oy - Probe Payload Library
+ * Attack payload strings organized by vulnerability category
+ *
+ * Each probe includes:
+ * - payload: The string to inject
+ * - category: Which vuln type it tests for
+ * - technique: Specific technique name
+ * - injected_delay: Expected delay for time-based probes
+ *
+ * @copyright 2026 Bountyy Oy
+ * @license Proprietary
+ */
+
+/// A single probe payload
+#[derive(Debug, Clone)]
+pub struct Probe {
+    pub payload: String,
+    pub category: String,
+    pub technique: String,
+    pub injected_delay: Option<f64>,
+}
+
+impl Probe {
+    pub fn new(payload: &str, category: &str, technique: &str, delay: Option<f64>) -> Self {
+        Self {
+            payload: payload.to_string(),
+            category: category.to_string(),
+            technique: technique.to_string(),
+            injected_delay: delay,
+        }
+    }
+}
+
+/// Get all probes for a given category
+pub fn get_probes(category: &str) -> Vec<Probe> {
+    match category {
+        "sqli" => sqli_probes(),
+        "xss" => xss_probes(),
+        "ssti" => ssti_probes(),
+        "cmdi" => cmdi_probes(),
+        "traversal" => traversal_probes(),
+        _ => Vec::new(),
+    }
+}
+
+/// SQL injection probe payloads
+pub fn sqli_probes() -> Vec<Probe> {
+    vec![
+        // Error-based
+        Probe::new("'", "sqli", "error_based", None),
+        Probe::new("\"", "sqli", "error_based", None),
+        Probe::new("' OR '1'='1", "sqli", "error_based", None),
+        Probe::new("1' ORDER BY 1--", "sqli", "union_discovery", None),
+        Probe::new("1' UNION SELECT NULL--", "sqli", "union_based", None),
+        Probe::new("1' UNION SELECT NULL,NULL--", "sqli", "union_based", None),
+        // Time-based
+        Probe::new("1' AND SLEEP(5)--", "sqli", "time_based", Some(5.0)),
+        Probe::new(
+            "1'; WAITFOR DELAY '0:0:5'--",
+            "sqli",
+            "time_based",
+            Some(5.0),
+        ),
+        Probe::new(
+            "1' AND pg_sleep(5)--",
+            "sqli",
+            "time_based",
+            Some(5.0),
+        ),
+        // Boolean-based
+        Probe::new("1' AND '1'='1", "sqli", "boolean_true", None),
+        Probe::new("1' AND '1'='2", "sqli", "boolean_false", None),
+    ]
+}
+
+/// XSS probe payloads
+pub fn xss_probes() -> Vec<Probe> {
+    vec![
+        Probe::new("<script>alert(1)</script>", "xss", "reflected", None),
+        Probe::new(
+            "<img src=x onerror=alert(1)>",
+            "xss",
+            "event_handler",
+            None,
+        ),
+        Probe::new("<svg onload=alert(1)>", "xss", "svg_event", None),
+        Probe::new("javascript:alert(1)", "xss", "js_uri", None),
+        Probe::new(
+            "\"onmouseover=\"alert(1)",
+            "xss",
+            "attr_breakout",
+            None,
+        ),
+        Probe::new("'-alert(1)-'", "xss", "script_context", None),
+        // Encoding bypass
+        Probe::new(
+            "%3Cscript%3Ealert(1)%3C/script%3E",
+            "xss",
+            "url_encoded",
+            None,
+        ),
+        Probe::new(
+            "<ScRiPt>alert(1)</ScRiPt>",
+            "xss",
+            "case_bypass",
+            None,
+        ),
+    ]
+}
+
+/// SSTI probe payloads
+pub fn ssti_probes() -> Vec<Probe> {
+    vec![
+        Probe::new("{{7*7}}", "ssti", "jinja2_twig", None),
+        Probe::new("{{7*'7'}}", "ssti", "twig_specific", None),
+        Probe::new("${7*7}", "ssti", "freemarker_mako", None),
+        Probe::new("<%= 7*7 %>", "ssti", "erb_ejs", None),
+        Probe::new("#{7*7}", "ssti", "ruby_interp", None),
+        Probe::new("${{7*7}}", "ssti", "polyglot", None),
+    ]
+}
+
+/// Command injection probe payloads
+pub fn cmdi_probes() -> Vec<Probe> {
+    vec![
+        Probe::new(";id", "cmdi", "unix_chain", None),
+        Probe::new("|id", "cmdi", "unix_pipe", None),
+        Probe::new("$(id)", "cmdi", "unix_subshell", None),
+        Probe::new("`id`", "cmdi", "unix_backtick", None),
+        Probe::new(";cat /etc/passwd", "cmdi", "file_read", None),
+        Probe::new("| type C:\\Windows\\win.ini", "cmdi", "windows_read", None),
+        // Time-based
+        Probe::new(";sleep 5", "cmdi", "time_based", Some(5.0)),
+        Probe::new(
+            "| ping -c 5 127.0.0.1",
+            "cmdi",
+            "time_based",
+            Some(5.0),
+        ),
+        Probe::new(
+            "& timeout /t 5",
+            "cmdi",
+            "windows_time_based",
+            Some(5.0),
+        ),
+    ]
+}
+
+/// Path traversal probe payloads
+pub fn traversal_probes() -> Vec<Probe> {
+    vec![
+        Probe::new("../../../../etc/passwd", "traversal", "unix_passwd", None),
+        Probe::new(
+            "....//....//....//etc/passwd",
+            "traversal",
+            "filter_bypass",
+            None,
+        ),
+        Probe::new(
+            "..%2f..%2f..%2fetc%2fpasswd",
+            "traversal",
+            "url_encoded",
+            None,
+        ),
+        Probe::new(
+            "..\\..\\..\\windows\\win.ini",
+            "traversal",
+            "windows_ini",
+            None,
+        ),
+        Probe::new(
+            "../../../../etc/passwd%00.jpg",
+            "traversal",
+            "null_byte",
+            None,
+        ),
+        Probe::new("../../../../.env", "traversal", "dotenv", None),
+        Probe::new(
+            "/etc/passwd",
+            "traversal",
+            "absolute_path",
+            None,
+        ),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sqli_probes_not_empty() {
+        let probes = sqli_probes();
+        assert!(!probes.is_empty());
+        assert!(probes.iter().all(|p| p.category == "sqli"));
+    }
+
+    #[test]
+    fn test_xss_probes_not_empty() {
+        let probes = xss_probes();
+        assert!(!probes.is_empty());
+        assert!(probes.iter().all(|p| p.category == "xss"));
+    }
+
+    #[test]
+    fn test_ssti_probes_not_empty() {
+        let probes = ssti_probes();
+        assert!(!probes.is_empty());
+        assert!(probes.iter().all(|p| p.category == "ssti"));
+    }
+
+    #[test]
+    fn test_cmdi_probes_not_empty() {
+        let probes = cmdi_probes();
+        assert!(!probes.is_empty());
+        assert!(probes.iter().all(|p| p.category == "cmdi"));
+    }
+
+    #[test]
+    fn test_traversal_probes_not_empty() {
+        let probes = traversal_probes();
+        assert!(!probes.is_empty());
+        assert!(probes.iter().all(|p| p.category == "traversal"));
+    }
+
+    #[test]
+    fn test_get_probes_valid_category() {
+        let probes = get_probes("sqli");
+        assert!(!probes.is_empty());
+    }
+
+    #[test]
+    fn test_get_probes_unknown_category() {
+        let probes = get_probes("nonexistent");
+        assert!(probes.is_empty());
+    }
+
+    #[test]
+    fn test_time_based_probes_have_delay() {
+        let probes = sqli_probes();
+        let time_based: Vec<_> = probes
+            .iter()
+            .filter(|p| p.technique == "time_based")
+            .collect();
+        assert!(!time_based.is_empty());
+        assert!(time_based.iter().all(|p| p.injected_delay.is_some()));
+    }
+}

--- a/src/scanners/mod.rs
+++ b/src/scanners/mod.rs
@@ -2500,7 +2500,7 @@ impl ScanEngine {
         // ============================================================
         // ML INTEGRATION - AUTOMATIC LEARNING FROM SCAN RESULTS
         // ============================================================
-        // Process vulnerabilities for federated learning (runs in background)
+        // Process vulnerabilities for ML learning (runs in background)
         if let Some(ref ml) = self.ml_integration {
             // Learn from each vulnerability found
             for vuln in &results.vulnerabilities {
@@ -2517,7 +2517,7 @@ impl ScanEngine {
                 }
             }
 
-            // Notify ML system that scan is complete (triggers federated sync if enabled)
+            // Notify ML system that scan is complete (triggers model sync)
             if let Err(e) = ml.scan_complete().await {
                 debug!("ML scan_complete failed: {}", e);
             }

--- a/src/scorer.rs
+++ b/src/scorer.rs
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 Bountyy Oy. All rights reserved.
+// This software is proprietary and confidential.
+
+/**
+ * Bountyy Oy - Model Scorer
+ * Scores extracted features against model weights to determine vulnerability likelihood
+ *
+ * @copyright 2026 Bountyy Oy
+ * @license Proprietary
+ */
+use crate::ml::federated::AggregatedModel;
+use std::collections::HashMap;
+
+/// Scores extracted features against model weights
+pub struct ModelScorer {
+    pub weights: HashMap<String, f64>,
+    pub bias: f64,
+}
+
+impl ModelScorer {
+    pub fn from_model(model: &AggregatedModel) -> Self {
+        Self {
+            weights: model.weights.weights.clone(),
+            bias: model.weights.bias,
+        }
+    }
+
+    /// Score extracted features. Returns raw score.
+    /// score > 0.0 means likely vulnerable.
+    pub fn score(&self, features: &HashMap<String, f64>) -> f64 {
+        let mut score = self.bias;
+        for (key, value) in features {
+            if let Some(weight) = self.weights.get(key.as_str()) {
+                score += value * weight;
+            }
+        }
+        score
+    }
+
+    /// Score and return category breakdown for reporting
+    pub fn score_detailed(&self, features: &HashMap<String, f64>) -> ScoredResult {
+        let mut total = self.bias;
+        let mut contributions: Vec<(String, f64)> = Vec::new();
+
+        for (key, value) in features {
+            if let Some(weight) = self.weights.get(key.as_str()) {
+                let contribution = value * weight;
+                total += contribution;
+                if contribution.abs() > 0.01 {
+                    contributions.push((key.clone(), contribution));
+                }
+            }
+        }
+
+        // Sort by absolute contribution (most impactful first)
+        contributions.sort_by(|a, b| b.1.abs().partial_cmp(&a.1.abs()).unwrap_or(std::cmp::Ordering::Equal));
+
+        ScoredResult {
+            score: total,
+            is_vulnerable: total > 0.0,
+            confidence: sigmoid(total),
+            top_signals: contributions.into_iter().take(5).collect(),
+        }
+    }
+}
+
+fn sigmoid(x: f64) -> f64 {
+    1.0 / (1.0 + (-x).exp())
+}
+
+/// Result of scoring features against model weights
+pub struct ScoredResult {
+    pub score: f64,
+    pub is_vulnerable: bool,
+    /// 0.0-1.0 confidence score
+    pub confidence: f64,
+    /// Top contributing features and their score contribution
+    pub top_signals: Vec<(String, f64)>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scorer_positive() {
+        let scorer = ModelScorer {
+            weights: [
+                ("sqli:error_mysql_syntax".to_string(), 2.0),
+                ("signal:error_triggered".to_string(), 0.5),
+            ]
+            .into_iter()
+            .collect(),
+            bias: -0.42,
+        };
+
+        let mut features = HashMap::new();
+        features.insert("sqli:error_mysql_syntax".to_string(), 0.95);
+        features.insert("signal:error_triggered".to_string(), 1.0);
+
+        let result = scorer.score_detailed(&features);
+        assert!(result.is_vulnerable);
+        assert!(result.score > 0.0);
+        assert!(result.confidence > 0.5);
+    }
+
+    #[test]
+    fn test_scorer_negative() {
+        let scorer = ModelScorer {
+            weights: [
+                ("sqli:error_mysql_syntax".to_string(), 0.3),
+                ("sqli:waf_blocked_response".to_string(), -1.5),
+            ]
+            .into_iter()
+            .collect(),
+            bias: -0.42,
+        };
+
+        let mut features = HashMap::new();
+        features.insert("sqli:waf_blocked_response".to_string(), 1.0);
+
+        let result = scorer.score_detailed(&features);
+        assert!(!result.is_vulnerable);
+        assert!(result.score < 0.0);
+    }
+
+    #[test]
+    fn test_scorer_missing_features() {
+        let scorer = ModelScorer {
+            weights: [("sqli:error_mysql_syntax".to_string(), 2.0)]
+                .into_iter()
+                .collect(),
+            bias: -0.42,
+        };
+
+        let mut features = HashMap::new();
+        features.insert("unknown_feature".to_string(), 1.0);
+
+        let result = scorer.score(&features);
+        // Only bias contributes, unknown features ignored
+        assert!((result - (-0.42)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_sigmoid() {
+        assert!((sigmoid(0.0) - 0.5).abs() < f64::EPSILON);
+        assert!(sigmoid(5.0) > 0.99);
+        assert!(sigmoid(-5.0) < 0.01);
+    }
+
+    #[test]
+    fn test_top_signals_sorted() {
+        let scorer = ModelScorer {
+            weights: [
+                ("a".to_string(), 0.1),
+                ("b".to_string(), 2.0),
+                ("c".to_string(), 0.5),
+            ]
+            .into_iter()
+            .collect(),
+            bias: 0.0,
+        };
+
+        let mut features = HashMap::new();
+        features.insert("a".to_string(), 1.0);
+        features.insert("b".to_string(), 1.0);
+        features.insert("c".to_string(), 1.0);
+
+        let result = scorer.score_detailed(&features);
+        assert_eq!(result.top_signals[0].0, "b");
+        assert_eq!(result.top_signals[1].0, "c");
+        assert_eq!(result.top_signals[2].0, "a");
+    }
+}


### PR DESCRIPTION
…d feature extraction layer

API changes:
- Add X-License-Key header to model download requests (GET /model/latest)
- Handle 401 with "Valid license required to download detection model" message
- Remove all federated contribution code (POST /contribute, WeightContribution, differential privacy noise, weight collection/aggregation)
- Remove /stats endpoint usage, add /model/categories endpoint
- Remove --federated flag from ML enable command
- Simplify ML sync to only fetch detection model

Feature extraction layer:
- Add src/scorer.rs: Model scorer that multiplies features by weights + bias
- Add src/features/mod.rs: Feature extraction dispatch by probe category
- Add src/features/sqli.rs: SQL injection feature extraction (error-based, time-based, boolean-based, false positive suppression)
- Add src/features/xss.rs: XSS feature extraction (reflection detection, context analysis, CSP analysis, false positive suppression)
- Add src/features/ssti.rs: Template injection feature extraction
- Add src/features/cmdi.rs: Command injection feature extraction
- Add src/features/traversal.rs: Path traversal feature extraction
- Add src/features/signals.rs: Cross-cutting signal features (response anomalies, WAF detection, content type mismatch)
- Add src/probes/mod.rs: Probe payload library (SQLi, XSS, SSTI, CMDi, traversal)

https://claude.ai/code/session_01YQaZEQLdm2KB2Ht3mpFMbo