### PR TITLE
Fix unclosed character class in sandbox regex pattern

### DIFF
--- a/src/scanners/postmessage_vulns.rs
+++ b/src/scanners/postmessage_vulns.rs
@@ -868,7 +868,7 @@ impl PostMessageVulnsScanner {
             .map(|m| m.as_str().to_string());
 
         // Extract sandbox
-        let sandbox_regex = Regex::new(r#"(?i)sandbox\s*=\s*['"]([^'"]*)['"#).unwrap();
+        let sandbox_regex = Regex::new(r#"(?i)sandbox\s*=\s*['"]([^'"]*)['"]"#).unwrap();
         let sandbox = sandbox_regex
             .captures(iframe_tag)
             .and_then(|c| c.get(1))


### PR DESCRIPTION
The regex on line 871 was missing a closing `]` in the final character
class `['"]`, causing a regex parse error panic when analyzing iframe
sandbox attributes. Added the missing bracket to match the correct
pattern used by the adjacent src_regex.

https://claude.ai/code/session_01By8oPBLaDst61qfe18Pps9