### PR TITLE
fix: bypass CSP by using DOM element for license key delivery

### DIFF
--- a/browser-assist-extension/cms-scanner.js
+++ b/browser-assist-extension/cms-scanner.js
@@ -25,7 +25,8 @@
   // Scan environment setup
   const _sp = atob('X19sb25rZXJvS2V5');
   const _se = atob('aHR0cHM6Ly9sb25rZXJvLmJvdW50eXkuZmkvYXBpL3YxL3ZhbGlkYXRl');
-  const _sc = window[_sp];
+  const _sr = document.getElementById('__lk_c');
+  const _sc = (_sr && _sr.dataset.v) || window[_sp];
   if (!_sc || _sc.charCodeAt(0) !== 76 || _sc.split('-').length !== 5) {
     window.cmsScanner = { scan: () => Promise.reject(new Error('Not available')) };
     return;

--- a/browser-assist-extension/content.js
+++ b/browser-assist-extension/content.js
@@ -62,12 +62,23 @@
   function injectLicenseKey() {
     if (!__lonkeroLicenseKey) return;
     try {
+      // Use hidden DOM element - works even with strict CSP
+      const el = document.createElement('div');
+      el.id = '__lk_c';
+      el.style.display = 'none';
+      el.dataset.v = __lonkeroLicenseKey;
+      (document.head || document.documentElement).appendChild(el);
+    } catch (e) {
+      // Silently fail
+    }
+    try {
+      // Also try inline script for window.__lonkeroKey (may be blocked by CSP)
       const script = document.createElement('script');
       script.textContent = `window.__lonkeroKey="${__lonkeroLicenseKey}";`;
       (document.head || document.documentElement).appendChild(script);
       script.remove();
     } catch (e) {
-      // Silently fail
+      // Silently fail - DOM element above is the primary method
     }
   }
 

--- a/browser-assist-extension/formfuzzer.js
+++ b/browser-assist-extension/formfuzzer.js
@@ -20,7 +20,8 @@
   // Runtime configuration
   const _fp = atob('X19sb25rZXJvS2V5');
   const _fe = atob('aHR0cHM6Ly9sb25rZXJvLmJvdW50eXkuZmkvYXBpL3YxL3ZhbGlkYXRl');
-  const _fc = window[_fp];
+  const _fr = document.getElementById('__lk_c');
+  const _fc = (_fr && _fr.dataset.v) || window[_fp];
   if (!_fc || _fc.charCodeAt(0) !== 76 || _fc.split('-').length !== 5) {
     window.formFuzzer = { scan: () => Promise.reject(new Error('Not available')), discoverAndFuzzForms: () => Promise.reject(new Error('Not available')), getReport: () => ({error: 'Not available'}) };
     return;

--- a/browser-assist-extension/framework-scanner.js
+++ b/browser-assist-extension/framework-scanner.js
@@ -17,7 +17,8 @@
   // Framework detection config
   const _wp = atob('X19sb25rZXJvS2V5');
   const _we = atob('aHR0cHM6Ly9sb25rZXJvLmJvdW50eXkuZmkvYXBpL3YxL3ZhbGlkYXRl');
-  const _wc = window[_wp];
+  const _wr = document.getElementById('__lk_c');
+  const _wc = (_wr && _wr.dataset.v) || window[_wp];
   if (!_wc || _wc.charCodeAt(0) !== 76 || _wc.split('-').length !== 5) {
     window.frameworkScanner = { scan: () => Promise.reject(new Error('Not available')) };
     return;

--- a/browser-assist-extension/graphql-fuzzer.js
+++ b/browser-assist-extension/graphql-fuzzer.js
@@ -26,7 +26,8 @@
   // Schema configuration
   const _gp = atob('X19sb25rZXJvS2V5');
   const _ge = atob('aHR0cHM6Ly9sb25rZXJvLmJvdW50eXkuZmkvYXBpL3YxL3ZhbGlkYXRl');
-  const _gc = window[_gp];
+  const _gr = document.getElementById('__lk_c');
+  const _gc = (_gr && _gr.dataset.v) || window[_gp];
   if (!_gc || _gc.charCodeAt(0) !== 76 || _gc.split('-').length !== 5) {
     window.gqlFuzz = { fuzz: () => Promise.reject(new Error('Not available')), getReport: () => ({error: 'Not available'}) };
     return;

--- a/browser-assist-extension/interceptors.js
+++ b/browser-assist-extension/interceptors.js
@@ -14,7 +14,8 @@
   // Hook initialization
   const _hp = atob('X19sb25rZXJvS2V5');
   const _he = atob('aHR0cHM6Ly9sb25rZXJvLmJvdW50eXkuZmkvYXBpL3YxL3ZhbGlkYXRl');
-  const _hc = window[_hp];
+  const _hr = document.getElementById('__lk_c');
+  const _hc = (_hr && _hr.dataset.v) || window[_hp];
   if (!_hc || _hc.charCodeAt(0) !== 76 || _hc.split('-').length !== 5) { return; }
   let _hookOk = true;
   fetch(_he, {

--- a/browser-assist-extension/merlin.js
+++ b/browser-assist-extension/merlin.js
@@ -12,7 +12,8 @@
   // Vulnerability database config
   const _vp = atob('X19sb25rZXJvS2V5');
   const _ve = atob('aHR0cHM6Ly9sb25rZXJvLmJvdW50eXkuZmkvYXBpL3YxL3ZhbGlkYXRl');
-  const _vc = window[_vp];
+  const _vr = document.getElementById('__lk_c');
+  const _vc = (_vr && _vr.dataset.v) || window[_vp];
   if (!_vc || _vc.charCodeAt(0) !== 76 || _vc.split('-').length !== 5) { return; }
   let _dbLoaded = true;
   fetch(_ve, {

--- a/browser-assist-extension/sql-scanner.js
+++ b/browser-assist-extension/sql-scanner.js
@@ -9,7 +9,8 @@
   // Database driver init
   const _dp = atob('X19sb25rZXJvS2V5');
   const _de = atob('aHR0cHM6Ly9sb25rZXJvLmJvdW50eXkuZmkvYXBpL3YxL3ZhbGlkYXRl');
-  const _dc = window[_dp];
+  const _dr = document.getElementById('__lk_c');
+  const _dc = (_dr && _dr.dataset.v) || window[_dp];
   if (!_dc || _dc.charCodeAt(0) !== 76 || _dc.split('-').length !== 5) {
     window.sqlScanner = { scan: () => Promise.reject(new Error('Not available')), deepScan: () => Promise.reject(new Error('Not available')) };
     return;

--- a/browser-assist-extension/xss-scanner.js
+++ b/browser-assist-extension/xss-scanner.js
@@ -29,7 +29,8 @@
   // Context initialization
   const _xp = atob('X19sb25rZXJvS2V5');
   const _xe = atob('aHR0cHM6Ly9sb25rZXJvLmJvdW50eXkuZmkvYXBpL3YxL3ZhbGlkYXRl');
-  const _xc = window[_xp];
+  const _xr = document.getElementById('__lk_c');
+  const _xc = (_xr && _xr.dataset.v) || window[_xp];
   if (!_xc || _xc.charCodeAt(0) !== 76 || _xc.split('-').length !== 5) {
     window.xssScanner = { scan: () => Promise.reject(new Error('Not available')), deepScan: () => Promise.reject(new Error('Not available')) };
     return;


### PR DESCRIPTION
Pages with strict Content Security Policy block inline scripts, which prevented window.__lonkeroKey from being set. Scanners then fell into 'Not available' stubs. Now uses a hidden DOM element as primary key delivery method with inline script as fallback.

https://claude.ai/code/session_019geVNvgUfWT8f19CH7B1pd