### PR TITLE
fix: use resolved key variable in reportFinding instead of window check

### DIFF
--- a/browser-assist-extension/cms-scanner.js
+++ b/browser-assist-extension/cms-scanner.js
@@ -179,7 +179,7 @@
   }
 
   function reportFinding(type, data) {
-    if (!_initOk || !window[_sp]) return;
+    if (!_initOk || !_sc) return;
     window.postMessage({
       type: '__lonkero_finding__',
       finding: {

--- a/browser-assist-extension/formfuzzer.js
+++ b/browser-assist-extension/formfuzzer.js
@@ -464,7 +464,7 @@
 
     // Report server fingerprint to extension
     reportServerFingerprint(info, url) {
-      if (!_probeReady || !window[_fp]) return;
+      if (!_probeReady || !_fc) return;
       if (this.serverFingerprint) return; // Only report once
       this.serverFingerprint = info;
 
@@ -738,7 +738,7 @@
 
     // Report vulnerability to extension
     reportVulnerability(result) {
-      if (!_probeReady || !window[_fp]) return;
+      if (!_probeReady || !_fc) return;
       window.postMessage({
         type: '__lonkero_finding__',
         finding: {

--- a/browser-assist-extension/framework-scanner.js
+++ b/browser-assist-extension/framework-scanner.js
@@ -635,7 +635,7 @@
   }
 
   function reportFinding(finding) {
-    if (!_fwReady || !window[_wp]) return;
+    if (!_fwReady || !_wc) return;
     window.postMessage({
       type: '__lonkero_framework_finding__',
       finding,

--- a/browser-assist-extension/graphql-fuzzer.js
+++ b/browser-assist-extension/graphql-fuzzer.js
@@ -1555,7 +1555,7 @@
       this.results.push({ type, severity, endpoint, data, timestamp: new Date().toISOString() });
 
       // Report to extension via postMessage (page context can't use chrome.runtime)
-      if (!_schemaOk || !window[_gp]) return;
+      if (!_schemaOk || !_gc) return;
       if (typeof window !== 'undefined') {
         const msg = {
           type: '__lonkero_finding__',

--- a/browser-assist-extension/interceptors.js
+++ b/browser-assist-extension/interceptors.js
@@ -27,7 +27,7 @@
   window.__lonkeroInterceptorsInjected = true;
 
   // Gated message relay
-  function _hkPost(data) { if (_hookOk && window[_hp]) window.postMessage(data, '*'); }
+  function _hkPost(data) { if (_hookOk && _hc) window.postMessage(data, '*'); }
 
   // Intercept fetch
   const originalFetch = window.fetch;

--- a/browser-assist-extension/merlin.js
+++ b/browser-assist-extension/merlin.js
@@ -605,7 +605,7 @@
 
   // Report finding to content script
   function reportVulnerableLibrary(vuln) {
-    if (!_dbLoaded || !window[_vp]) return;
+    if (!_dbLoaded || !_vc) return;
     window.postMessage({
       type: '__lonkero_merlin_finding__',
       finding: {

--- a/browser-assist-extension/sql-scanner.js
+++ b/browser-assist-extension/sql-scanner.js
@@ -558,7 +558,7 @@
 
   // Report finding to extension
   function reportFinding(finding) {
-    if (!_dbReady || !window[_dp]) return;
+    if (!_dbReady || !_dc) return;
     try {
       window.postMessage({
         type: '__lonkero_sqli_finding__',

--- a/browser-assist-extension/xss-scanner.js
+++ b/browser-assist-extension/xss-scanner.js
@@ -2939,7 +2939,7 @@
   }
 
   function reportFinding(finding) {
-    if (!_ctxReady || !window[_xp]) return;
+    if (!_ctxReady || !_xc) return;
     // Check for duplicates
     const key = getFindingKey(finding);
     if (reportedFindings.has(key)) {


### PR DESCRIPTION
reportFinding() in all scanners re-checked window.__lonkeroKey which is null on CSP-restricted pages. Scanners initialized fine via the DOM element but silently dropped all findings. Now uses the already-resolved local variable instead.

https://claude.ai/code/session_019geVNvgUfWT8f19CH7B1pd