### PR TITLE
fix: remove inline script fallback that triggers CSP errors

### DIFF
--- a/browser-assist-extension/content.js
+++ b/browser-assist-extension/content.js
@@ -62,7 +62,6 @@
   function injectLicenseKey() {
     if (!__lonkeroLicenseKey) return;
     try {
-      // Use hidden DOM element - works even with strict CSP
       const el = document.createElement('div');
       el.id = '__lk_c';
       el.style.display = 'none';
@@ -70,15 +69,6 @@
       (document.head || document.documentElement).appendChild(el);
     } catch (e) {
       // Silently fail
-    }
-    try {
-      // Also try inline script for window.__lonkeroKey (may be blocked by CSP)
-      const script = document.createElement('script');
-      script.textContent = `window.__lonkeroKey="${__lonkeroLicenseKey}";`;
-      (document.head || document.documentElement).appendChild(script);
-      script.remove();
-    } catch (e) {
-      // Silently fail - DOM element above is the primary method
     }
   }
 


### PR DESCRIPTION
The DOM element method works everywhere - no need for the inline script fallback that generates red CSP errors in console.

https://claude.ai/code/session_019geVNvgUfWT8f19CH7B1pd