### PR TITLE
security: fix all remaining review findings — HMAC auth, SSRF deny, f…

### DIFF
--- a/browser-assist-extension/content.js
+++ b/browser-assist-extension/content.js
@@ -83,6 +83,9 @@
       el.dataset.n = __msgNonce;
       el.dataset.e = __evtChannel;
       (document.head || document.documentElement).appendChild(el);
+
+      // Remove the element after scanners have read it (reduce exposure window)
+      setTimeout(() => { try { el.remove(); } catch {} }, 2000);
     } catch (e) {
       // Silently fail
     }
@@ -2089,27 +2092,41 @@
     }
 
     // Handle generic findings from injected scripts (formfuzzer, graphql-fuzzer, etc.)
+    // Whitelist fields to prevent untrusted page data from polluting extension state
     if (event.data?.type === '__lonkero_finding__') {
-      console.log('[Lonkero Content] Received __lonkero_finding__:', event.data);
       const finding = event.data.finding;
       if (finding && finding.type) {
-        console.log('[Lonkero Content] Calling reportFinding for:', finding.type);
-        reportFinding(finding.type, {
-          ...finding,
-          url: finding.url || location.href,
+        reportFinding(String(finding.type).slice(0, 100), {
+          url: finding.url ? String(finding.url).slice(0, 2000) : location.href,
+          severity: finding.severity ? String(finding.severity).slice(0, 20) : undefined,
+          evidence: finding.evidence ? String(finding.evidence).slice(0, 500) : undefined,
+          parameter: finding.parameter ? String(finding.parameter).slice(0, 200) : undefined,
+          context: finding.context ? String(finding.context).slice(0, 500) : undefined,
+          sink: finding.sink ? String(finding.sink).slice(0, 100) : undefined,
+          source: finding.source ? String(finding.source).slice(0, 200) : undefined,
+          element: finding.element ? String(finding.element).slice(0, 100) : undefined,
+          value: finding.value ? String(finding.value).slice(0, 500) : undefined,
+          valuePreview: finding.valuePreview ? String(finding.valuePreview).slice(0, 200) : undefined,
+          codePreview: finding.codePreview ? String(finding.codePreview).slice(0, 200) : undefined,
+          version: finding.version ? String(finding.version).slice(0, 50) : undefined,
+          library: finding.library ? String(finding.library).slice(0, 100) : undefined,
+          description: finding.description ? String(finding.description).slice(0, 500) : undefined,
+          category: finding.category ? String(finding.category).slice(0, 100) : undefined,
+          proof: finding.proof ? String(finding.proof).slice(0, 500) : undefined,
         });
       }
     }
 
     // Handle framework scanner findings
     if (event.data?.type === '__lonkero_framework_finding__') {
-      console.log('[Lonkero Content] Received framework finding:', event.data);
       const finding = event.data.finding;
       if (finding && finding.type) {
-        console.log('[Lonkero Content] Calling reportFinding for framework:', finding.type);
-        reportFinding(finding.type, {
-          ...finding,
-          url: finding.url || location.href,
+        reportFinding(String(finding.type).slice(0, 100), {
+          url: finding.url ? String(finding.url).slice(0, 2000) : location.href,
+          severity: finding.severity ? String(finding.severity).slice(0, 20) : undefined,
+          evidence: finding.evidence ? String(finding.evidence).slice(0, 500) : undefined,
+          version: finding.version ? String(finding.version).slice(0, 50) : undefined,
+          description: finding.description ? String(finding.description).slice(0, 500) : undefined,
           scanner: 'framework-scanner',
         });
       }

--- a/browser-assist-extension/framework-scanner.js
+++ b/browser-assist-extension/framework-scanner.js
@@ -25,8 +25,9 @@
   }
   let _fwReady = true;
 
-  if (window.__lkFW) return;
-  window.__lkFW = true;
+  const _fwGuard = Symbol.for('__lkFW_' + (_wn || ''));
+  if (window[_fwGuard]) return;
+  window[_fwGuard] = true;
 
   const findings = [];
 

--- a/browser-assist-extension/interceptors.js
+++ b/browser-assist-extension/interceptors.js
@@ -19,8 +19,9 @@
   const _he = _hr ? _hr.dataset.e : null; // Per-session channel
   let _hookOk = true;
 
-  if (window.__lkIC) return;
-  window.__lkIC = true;
+  const _icGuard = Symbol.for('__lkIC_' + (_hn || ''));
+  if (window[_icGuard]) return;
+  window[_icGuard] = true;
 
   // Gated message relay (includes session nonce + channel)
   function _hkPost(data) { if (_hookOk && _hc && _he) { data._n = _hn; data._ch = _he; window.postMessage(data, '*'); } }

--- a/browser-assist-extension/merlin.js
+++ b/browser-assist-extension/merlin.js
@@ -17,8 +17,9 @@
   if (!_vc || _vc.charCodeAt(0) !== 76 || _vc.split('-').length !== 5) { return; }
   let _dbLoaded = true;
 
-  if (window.__lkML) return;
-  window.__lkML = true;
+  const _mlGuard = Symbol.for('__lkML_' + (_vn || ''));
+  if (window[_mlGuard]) return;
+  window[_mlGuard] = true;
 
   // Vulnerability database - CVE data for JS libraries
   const VULN_DATABASE = {

--- a/browser-assist-extension/popup.html
+++ b/browser-assist-extension/popup.html
@@ -319,7 +319,7 @@
         Enter your license key below to activate.
       </p>
       <div style="margin-bottom: 12px;">
-        <input type="text" id="licenseKeyInput" placeholder="Enter your license key" style="width: 100%; padding: 10px 12px; background: #111; border: 1px solid #333; border-radius: 4px; color: #e0e0e0; font-family: 'JetBrains Mono', 'Cascadia Code', 'Fira Code', 'Consolas', 'Monaco', monospace; font-size: 12px; text-align: center;">
+        <input type="password" id="licenseKeyInput" placeholder="Enter your license key" autocomplete="off" style="width: 100%; padding: 10px 12px; background: #111; border: 1px solid #333; border-radius: 4px; color: #e0e0e0; font-family: 'JetBrains Mono', 'Cascadia Code', 'Fira Code', 'Consolas', 'Monaco', monospace; font-size: 12px; text-align: center;">
       </div>
       <div id="licenseError" style="color: #ff3939; font-size: 10px; margin-bottom: 10px; display: none;"></div>
       <div id="licenseSuccess" style="color: #39ff14; font-size: 10px; margin-bottom: 10px; display: none;"></div>

--- a/browser-assist-extension/sql-scanner.js
+++ b/browser-assist-extension/sql-scanner.js
@@ -17,11 +17,10 @@
   }
   let _dbReady = true;
 
-  // Prevent double-injection
-  if (window.sqlScanner) {
-    console.log('[SQLi Scanner] Already loaded');
-    return;
-  }
+  // Prevent double-injection (Symbol guard — not spoofable by page)
+  const _sqlGuard = Symbol.for('__lkSQ_' + (_dn || ''));
+  if (window[_sqlGuard]) return;
+  window[_sqlGuard] = true;
 
   const findings = [];
   const testedParams = new Set();

--- a/browser-assist-extension/xss-scanner.js
+++ b/browser-assist-extension/xss-scanner.js
@@ -37,8 +37,9 @@
   }
   let _ctxReady = true;
 
-  if (window.__lkXS) return;
-  window.__lkXS = true;
+  const _xsGuard = Symbol.for('__lkXS_' + (_xn || ''));
+  if (window[_xsGuard]) return;
+  window[_xsGuard] = true;
 
   // ============================================
   // REFLECTION CONTEXTS


### PR DESCRIPTION
…ield whitelist

CRITICAL fixes:
- #1: WS authentication now uses HMAC-SHA256 challenge-response with license key as shared secret. Rogue processes can no longer echo the challenge — they must know the license key. Falls back to challenge-echo only on first pairing (when extension has no stored key yet).
- #3: Add private IP deny list (RFC 1918, loopback, link-local, cloud metadata 169.254.169.254). Blocks SSRF to internal networks regardless of CLI-set scope. Applied to proxy, CLI replay, and popup replay.

HIGH fixes:
- #6+#7: Remove #__lk_c DOM element after 2s delay. Scanners read it synchronously on load; the element is gone before most page scripts can find it. Significantly reduces license key exposure window.

MEDIUM fixes:
- #8: Replace `...finding` spread with explicit field whitelist in content.js. Only known safe fields forwarded, all truncated to max lengths. Prevents untrusted page data from polluting extension state.
- #11: Replace guessable `window.__lkXS` etc. guards with Symbol-based guards keyed to session nonce. Pages can no longer pre-set globals to disable scanners.
- #14: Set tungstenite max_message_size=4MB, max_frame_size=2MB (was 64MB default). Prevents memory exhaustion from oversized WS messages.

LOW fixes:
- #15: Add isLicensed() gate to replayRequest handler.
- #18: License key input masked (type="password", autocomplete="off").

https://claude.ai/code/session_019geVNvgUfWT8f19CH7B1pd