### PR TITLE
security: fix Semgrep temp-dir and current-exe findings (#282, #283, …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,9 @@ dirs = "6.0"
 keyring = "3.6.3"
 socket2 = "0.6.2"
 
+# Secure temporary directory creation
+tempfile = "3.15"
+
 [profile.release]
 opt-level = 3
 lto = true
@@ -165,4 +168,3 @@ strip = false
 debug = true
 
 [dev-dependencies]
-tempfile = "3.15"


### PR DESCRIPTION
…#284)

- Replace std::env::temp_dir() with tempfile::TempDir for secure temp directory creation (random names, restricted permissions, auto-cleanup)
- Canonicalize current_exe() path to mitigate symlink manipulation
- Move tempfile from dev-dependencies to dependencies

https://claude.ai/code/session_019geVNvgUfWT8f19CH7B1pd