### PR TITLE
fix: resolve license key lookup for ML model downloads across all tiers

### DIFF
--- a/src/license/mod.rs
+++ b/src/license/mod.rs
@@ -1193,12 +1193,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_default_license_has_full_access() {
+    fn test_default_license_has_limited_access() {
         let status = LicenseStatus::default();
         assert!(status.valid);
         assert!(!status.killswitch_active);
-        assert!(status.features.contains(&"all_scanners".to_string()));
-        assert_eq!(status.max_targets, Some(100));
+        // Default offline license has only basic features (fail-closed)
+        assert!(status.features.contains(&"basic_scanners".to_string()));
+        assert!(status.features.contains(&"basic_outputs".to_string()));
+        assert!(!status.features.contains(&"all_scanners".to_string()));
+        assert_eq!(status.max_targets, Some(10));
     }
 
     #[test]

--- a/src/ml/integration.rs
+++ b/src/ml/integration.rs
@@ -53,10 +53,15 @@ impl MlPipeline {
         let privacy_manager = PrivacyManager::new()?;
         let enabled = privacy_manager.is_ml_allowed();
 
+        // Load license key into federated client so model downloads work
+        // for users who activated via `lonkero license activate` (stored in keychain)
+        let mut federated = FederatedClient::new()?;
+        federated.load_license_key();
+
         Ok(Self {
             auto_learner: Arc::new(RwLock::new(AutoLearner::new()?)),
             fp_classifier: Arc::new(RwLock::new(FalsePositiveClassifier::new()?)),
-            federated_client: Arc::new(RwLock::new(FederatedClient::new()?)),
+            federated_client: Arc::new(RwLock::new(federated)),
             privacy_manager: Arc::new(RwLock::new(privacy_manager)),
             enabled,
             findings_processed: 0,


### PR DESCRIPTION
The ML model download was only checking the LONKERO_LICENSE_KEY env var,
ignoring license keys stored in the OS keychain (set by `lonkero license
activate`) and CLI --license-key args. This caused all paid license
holders (Personal, Professional, Team, Enterprise) to get 401 errors
when downloading detection models.

Three fixes:
- run_scan() auto-download now checks CLI arg > env var > OS keychain
- FederatedClient.load_license_key() auto-discovers keys from all sources
- MlPipeline loads license key into FederatedClient on construction
- Fixed broken test_default_license_has_full_access test assertions

https://claude.ai/code/session_01KpdAvVgJxE2gg6zyeQYvco