### PR TITLE
Expand sensitive-data and info-disclosure detection

### DIFF
--- a/src/scanners/information_disclosure.rs
+++ b/src/scanners/information_disclosure.rs
@@ -83,7 +83,6 @@ impl InformationDisclosureScanner {
     /// Test for sensitive file exposure
     async fn test_sensitive_files(&self, url: &str) -> anyhow::Result<(Vec<Vulnerability>, usize)> {
         let mut vulnerabilities = Vec::new();
-        let tests_run = 25; // Updated count
 
         debug!("Testing sensitive file exposure");
 
@@ -93,32 +92,144 @@ impl InformationDisclosureScanner {
             "/.env.local",
             "/.env.production",
             "/.env.development",
+            "/.env.staging",
+            "/.env.prod",
             "/.env.backup",
+            "/.env.bak",
+            "/.env.save",
             // Config files
             "/config.php",
             "/config.json",
             "/config.yml",
+            "/config.yaml",
             "/web.config",
             "/app.config",
             "/configuration.php",
-            // Git files
+            "/appsettings.json",
+            "/appsettings.Production.json",
+            "/application.properties",
+            "/application.yml",
+            "/config/database.yml",
+            "/config/secrets.yml",
+            "/sites/default/settings.php",
+            "/app/etc/local.xml",
+            "/app/etc/env.php",
+            "/local_settings.py",
+            // Rails
+            "/config/master.key",
+            "/config/credentials.yml.enc",
+            // Git & VCS
             "/.git/config",
             "/.git/HEAD",
+            "/.git/index",
+            "/.git/logs/HEAD",
+            "/.svn/entries",
+            "/.svn/wc.db",
+            "/.hg/hgrc",
             // Package management
             "/composer.json",
+            "/composer.lock",
             "/package.json",
+            "/auth.json",
+            "/.npmrc",
             // Web server configs
             "/.htaccess",
+            "/.htpasswd",
             "/phpinfo.php",
             // Backup files
             "/backup.sql",
+            "/backup.sql.gz",
             "/db_backup.sql",
             "/database.sql",
+            "/production.sql",
+            "/prod.sql",
+            "/users.sql",
+            "/dump.sql",
+            "/dump.rdb",
             "/backup.zip",
-            "/config.php.bak",
-            "/index.php.old",
+            "/backup.tar.gz",
+            "/site.zip",
             "/site.tar.gz",
+            "/www.zip",
+            "/public_html.zip",
+            "/wwwroot.zip",
+            "/source.zip",
+            "/src.zip",
+            "/release.zip",
+            "/config.php.bak",
+            "/wp-config.php.bak",
+            "/wp-config.php.old",
+            "/index.php.old",
+            // Cloud credentials
+            "/.aws/credentials",
+            "/.aws/config",
+            "/credentials.csv",
+            "/credentials.json",
+            "/service-account.json",
+            "/firebase-adminsdk.json",
+            "/.docker/config.json",
+            "/.dockercfg",
+            "/.kube/config",
+            "/kubeconfig",
+            // Terraform / IaC state
+            "/terraform.tfstate",
+            "/terraform.tfstate.backup",
+            "/terraform.tfvars",
+            "/.terraform/terraform.tfstate",
+            // SSH / PEM
+            "/id_rsa",
+            "/id_ed25519",
+            "/.ssh/id_rsa",
+            "/.ssh/authorized_keys",
+            "/server.key",
+            "/server.pem",
+            "/private.key",
+            // Dotfiles containing secrets
+            "/.bash_history",
+            "/.zsh_history",
+            "/.netrc",
+            "/.pgpass",
+            "/.my.cnf",
+            "/.mysql_history",
+            "/.psql_history",
+            // IDE configs
+            "/.idea/dataSources.xml",
+            "/.idea/workspace.xml",
+            "/.vscode/sftp.json",
+            "/sftp-config.json",
+            // CI/CD
+            "/.travis.yml",
+            "/.circleci/config.yml",
+            "/.gitlab-ci.yml",
+            "/azure-pipelines.yml",
+            "/Jenkinsfile",
+            "/bitbucket-pipelines.yml",
+            "/buildspec.yml",
+            // Docker
+            "/Dockerfile",
+            "/docker-compose.yml",
+            "/docker-compose.override.yml",
+            "/docker-compose.prod.yml",
+            // Diagnostic / debug surfaces
+            "/elmah.axd",
+            "/trace.axd",
+            "/actuator/env",
+            "/actuator/heapdump",
+            "/actuator/configprops",
+            "/heapdump",
+            "/heapdump.hprof",
+            // Log files
+            "/error.log",
+            "/access.log",
+            "/laravel.log",
+            "/storage/logs/laravel.log",
+            "/logs/production.log",
+            "/nohup.out",
+            // Java / JSP
+            "/WEB-INF/web.xml",
+            "/META-INF/MANIFEST.MF",
         ];
+        let tests_run = sensitive_files.len();
 
         let base_url = self.extract_base_url(url);
 
@@ -131,14 +242,15 @@ impl InformationDisclosureScanner {
                         && self.detect_sensitive_content(&response.body, file)
                     {
                         info!("Sensitive file exposed: {}", file);
+                        let (severity, cwe) = Self::severity_for_sensitive_file(file);
                         vulnerabilities.push(self.create_vulnerability(
                             &test_url,
                             "Sensitive File Exposure",
                             file,
                             &format!("Sensitive file {} is publicly accessible", file),
                             &format!("File {} returned 200 OK with sensitive content", file),
-                            Severity::High,
-                            "CWE-200",
+                            severity,
+                            cwe,
                         ));
                         break;
                     }
@@ -512,12 +624,331 @@ impl InformationDisclosureScanner {
         }
     }
 
+    /// Map a sensitive file path to a severity tier and CWE.
+    /// Critical tier = direct credential/key material or full DB content.
+    fn severity_for_sensitive_file(file: &str) -> (Severity, &'static str) {
+        let f = file.to_lowercase();
+
+        // Direct credential material - rotate-immediately impact
+        let critical_paths: &[&str] = &[
+            "/.env",
+            "/.aws/credentials",
+            "/credentials.csv",
+            "/credentials.json",
+            "/service-account.json",
+            "/firebase-adminsdk.json",
+            "/.docker/config.json",
+            "/.dockercfg",
+            "/.kube/config",
+            "/kubeconfig",
+            "/config/master.key",
+            "/master.key",
+            "/terraform.tfstate",
+            "/terraform.tfstate.backup",
+            "/id_rsa",
+            "/id_ed25519",
+            "/id_dsa",
+            "/.ssh/id_rsa",
+            "/server.key",
+            "/private.key",
+            "/.htpasswd",
+            "/.netrc",
+            "/.pgpass",
+            "/.my.cnf",
+            "/auth.json",
+            "/.npmrc",
+            "/dump.rdb",
+            "/sites/default/settings.php",
+            "/app/etc/local.xml",
+            "/app/etc/env.php",
+            "/local_settings.py",
+            "/appsettings.production.json",
+            "/appsettings.json",
+            "/config/credentials.yml.enc",
+            "/.idea/datasources.xml",
+            "/.idea/datasources.local.xml",
+            "/.vscode/sftp.json",
+            "/sftp-config.json",
+        ];
+        for cp in critical_paths {
+            if f.ends_with(cp) || f == *cp {
+                return (Severity::Critical, "CWE-798");
+            }
+        }
+
+        // SQL dumps / archive backups / heap dumps - high-impact data disclosure
+        let high_paths_suffixes: &[&str] = &[
+            ".sql",
+            ".sql.gz",
+            ".sql.zip",
+            ".zip",
+            ".tar.gz",
+            ".tar",
+            ".hprof",
+            ".bak",
+            ".old",
+            ".rdb",
+            "/heapdump",
+            "/actuator/heapdump",
+            "/actuator/env",
+            "/trace.axd",
+            "/elmah.axd",
+        ];
+        for hp in high_paths_suffixes {
+            if f.ends_with(hp) {
+                return (Severity::High, "CWE-200");
+            }
+        }
+
+        (Severity::High, "CWE-200")
+    }
+
     /// Detect sensitive content in file using pattern-based detection
     /// This ensures we only report findings when actual sensitive patterns are found,
     /// not just based on response similarity or status codes.
     fn detect_sensitive_content(&self, body: &str, filename: &str) -> bool {
         if body.is_empty() || body.len() < 10 {
             return false;
+        }
+
+        let fname_lower = filename.to_lowercase();
+
+        // Cloud credentials - extremely high-confidence signatures
+        if fname_lower.ends_with("/.aws/credentials") || fname_lower.ends_with("/credentials.csv") {
+            return body.contains("aws_access_key_id") || body.contains("AKIA")
+                || (body.to_lowercase().contains("access key id")
+                    && body.to_lowercase().contains("secret access key"));
+        }
+        if fname_lower.ends_with("/.aws/config") {
+            return body.contains("[profile") || body.contains("[default]");
+        }
+        if fname_lower.ends_with("/.kube/config") || fname_lower.ends_with("/kubeconfig") {
+            return body.contains("apiVersion") && body.contains("clusters:")
+                && (body.contains("client-certificate-data")
+                    || body.contains("client-key-data")
+                    || body.contains("token:"));
+        }
+        if fname_lower.ends_with("/.docker/config.json") || fname_lower.ends_with("/.dockercfg") {
+            return body.contains("\"auths\"") || body.contains("\"auth\":");
+        }
+        if fname_lower.ends_with("/service-account.json")
+            || fname_lower.ends_with("/credentials.json")
+            || fname_lower.ends_with("/firebase-adminsdk.json")
+        {
+            return body.contains("\"type\": \"service_account\"")
+                || body.contains("\"type\":\"service_account\"")
+                || (body.contains("\"private_key\"") && body.contains("BEGIN PRIVATE KEY"));
+        }
+
+        // Terraform state contains every secret in plaintext
+        if fname_lower.ends_with(".tfstate") || fname_lower.ends_with(".tfstate.backup") {
+            return body.contains("\"terraform_version\"")
+                || body.contains("\"serial\"") && body.contains("\"resources\"")
+                || body.contains("\"lineage\"");
+        }
+        if fname_lower.ends_with(".tfvars") {
+            let lower = body.to_lowercase();
+            return (lower.contains("password") || lower.contains("secret")
+                || lower.contains("token") || lower.contains("api_key"))
+                && (body.contains("=") || body.contains(":"));
+        }
+
+        // Rails master key - 32-char hex only
+        if fname_lower.ends_with("/config/master.key") || fname_lower.ends_with("/master.key") {
+            let trimmed = body.trim();
+            return trimmed.len() >= 24 && trimmed.len() <= 128
+                && trimmed.chars().all(|c| c.is_ascii_hexdigit() || c == '\n' || c == '\r');
+        }
+
+        // Private key blocks
+        if fname_lower.ends_with("/id_rsa")
+            || fname_lower.ends_with("/id_ed25519")
+            || fname_lower.ends_with("/id_dsa")
+            || fname_lower.ends_with("/server.key")
+            || fname_lower.ends_with("/server.pem")
+            || fname_lower.ends_with("/private.key")
+        {
+            return body.contains("-----BEGIN")
+                && (body.contains("PRIVATE KEY-----")
+                    || body.contains("OPENSSH PRIVATE KEY-----"));
+        }
+
+        // SSH authorized_keys - public keys, signature of ssh- prefix
+        if fname_lower.ends_with("/authorized_keys") {
+            return body.contains("ssh-rsa ")
+                || body.contains("ssh-ed25519 ")
+                || body.contains("ecdsa-sha2-");
+        }
+
+        // .htpasswd - format username:$hash
+        if fname_lower.ends_with("/.htpasswd") {
+            return body.contains(":$2")
+                || body.contains(":$apr1$")
+                || body.contains(":{SHA}")
+                || body.contains(":$6$");
+        }
+
+        // .netrc / .pgpass / .my.cnf
+        if fname_lower.ends_with("/.netrc") {
+            return body.contains("machine ")
+                && (body.contains("login ") || body.contains("password "));
+        }
+        if fname_lower.ends_with("/.pgpass") {
+            return body.lines().any(|l| {
+                !l.starts_with('#') && l.matches(':').count() >= 4 && l.len() > 10
+            });
+        }
+        if fname_lower.ends_with("/.my.cnf") {
+            return (body.contains("[client]") || body.contains("[mysql]"))
+                && body.to_lowercase().contains("password");
+        }
+
+        // Shell history (commands suggest real history)
+        if fname_lower.ends_with("/.bash_history")
+            || fname_lower.ends_with("/.zsh_history")
+            || fname_lower.ends_with("/.mysql_history")
+            || fname_lower.ends_with("/.psql_history")
+        {
+            let indicators = [
+                "cd ", "sudo ", "ssh ", "mysql ", "psql ", "curl ", "wget ",
+                "export ", "git ", "scp ", "rsync ",
+            ];
+            let hits = indicators.iter().filter(|i| body.contains(*i)).count();
+            return hits >= 2;
+        }
+
+        // ELMAH / trace.axd
+        if fname_lower.ends_with("/elmah.axd") {
+            return body.contains("ELMAH") || body.contains("Error Log")
+                || body.contains("All Errors");
+        }
+        if fname_lower.ends_with("/trace.axd") {
+            return body.contains("Application Trace")
+                || body.contains("Request Details")
+                || body.contains("Trace Information");
+        }
+
+        // Spring Boot actuator endpoints
+        if fname_lower.contains("/actuator/env") {
+            return body.contains("\"propertySources\"") || body.contains("\"activeProfiles\"");
+        }
+        if fname_lower.contains("/actuator/configprops") {
+            return body.contains("\"contexts\"") || body.contains("\"properties\"")
+                || body.contains("\"configurationProperties\"");
+        }
+        if fname_lower.ends_with("/heapdump") || fname_lower.ends_with(".hprof")
+            || fname_lower.contains("/actuator/heapdump")
+        {
+            return body.starts_with("JAVA PROFILE");
+        }
+
+        // JetBrains / editor SFTP configs
+        if fname_lower.ends_with("/.idea/datasources.xml")
+            || fname_lower.ends_with("/.idea/datasources.local.xml")
+        {
+            return body.contains("<DataSource") || body.contains("jdbc:");
+        }
+        if fname_lower.ends_with("/.idea/workspace.xml") {
+            return body.contains("<project") && body.contains("version=\"4\"");
+        }
+        if fname_lower.ends_with("/.vscode/sftp.json") || fname_lower.ends_with("/sftp-config.json")
+        {
+            return body.contains("\"host\"")
+                && (body.contains("\"password\"")
+                    || body.contains("\"privateKeyPath\"")
+                    || body.contains("\"username\""));
+        }
+
+        // Drupal / Magento
+        if fname_lower.ends_with("/sites/default/settings.php") {
+            return body.contains("$databases") || body.contains("$settings['hash_salt']");
+        }
+        if fname_lower.ends_with("/app/etc/local.xml") {
+            return body.contains("<username>")
+                && body.contains("<password>")
+                && body.contains("<dbname>");
+        }
+        if fname_lower.ends_with("/app/etc/env.php") {
+            return body.contains("<?php") && body.contains("'db'")
+                && body.contains("'connection'");
+        }
+
+        // Django
+        if fname_lower.ends_with("/local_settings.py")
+            || fname_lower.ends_with("/settings.py")
+        {
+            return body.contains("SECRET_KEY")
+                && (body.contains("DATABASES") || body.contains("INSTALLED_APPS"));
+        }
+
+        // ASP.NET Core appsettings.json
+        if fname_lower.ends_with("/appsettings.json")
+            || fname_lower.contains("/appsettings.")
+        {
+            return (body.contains("\"ConnectionStrings\"")
+                || body.contains("\"ConnectionString\""))
+                && body.contains("Password");
+        }
+
+        // WEB-INF / META-INF
+        if fname_lower.contains("/web-inf/web.xml") {
+            return body.contains("<web-app") || body.contains("<servlet>");
+        }
+        if fname_lower.contains("/meta-inf/manifest.mf") {
+            return body.contains("Manifest-Version:");
+        }
+
+        // auth.json / .npmrc
+        if fname_lower.ends_with("/auth.json") {
+            return body.contains("\"http-basic\"")
+                || body.contains("\"github-oauth\"")
+                || body.contains("\"gitlab-token\"");
+        }
+        if fname_lower.ends_with("/.npmrc") {
+            return body.contains("_authToken")
+                || body.contains("//registry.npmjs.org/:_auth");
+        }
+
+        // Redis RDB snapshot - binary signature
+        if fname_lower.ends_with("/dump.rdb") {
+            return body.starts_with("REDIS");
+        }
+
+        // Laravel storage logs
+        if fname_lower.ends_with("/laravel.log")
+            || fname_lower.ends_with("/storage/logs/laravel.log")
+        {
+            return body.contains("production.ERROR")
+                || body.contains("local.ERROR")
+                || body.contains(".ERROR: ")
+                || body.contains("Stack trace:");
+        }
+
+        // CI/CD pipeline files - flag when secrets-like tokens appear
+        if fname_lower.ends_with("/.travis.yml")
+            || fname_lower.ends_with("/.circleci/config.yml")
+            || fname_lower.ends_with("/.gitlab-ci.yml")
+            || fname_lower.ends_with("/azure-pipelines.yml")
+            || fname_lower.ends_with("/bitbucket-pipelines.yml")
+            || fname_lower.ends_with("/jenkinsfile")
+            || fname_lower.ends_with("/buildspec.yml")
+        {
+            let lower = body.to_lowercase();
+            return (lower.contains("secure:") || lower.contains("secret")
+                || lower.contains("token") || lower.contains("password"))
+                && (body.contains(":") || body.contains("="));
+        }
+
+        // Docker compose - env and credentials
+        if fname_lower.ends_with("/dockerfile")
+            || fname_lower.contains("/docker-compose")
+        {
+            let lower = body.to_lowercase();
+            return (lower.contains("password")
+                || lower.contains("secret")
+                || lower.contains("api_key")
+                || lower.contains("_env"))
+                && (body.contains(":") || body.contains("="));
         }
 
         // Use pattern-based detection instead of relying on response similarity

--- a/src/scanners/sensitive_data.rs
+++ b/src/scanners/sensitive_data.rs
@@ -100,44 +100,172 @@ impl SensitiveDataScanner {
             "/.env.local",
             "/.env.production",
             "/.env.development",
+            "/.env.stage",
+            "/.env.staging",
+            "/.env.prod",
+            "/.env.dev",
+            "/.env.test",
+            "/.env.backup",
+            "/.env.bak",
+            "/.env.old",
+            "/.env.save",
+            "/.env.sample",
+            "/.env.example",
+            "/.env.default",
+            "/.env.live",
+            "/.env.private",
             "/config.php",
             "/configuration.php",
             "/wp-config.php",
             "/wp-config.php.bak",
+            "/wp-config.php.old",
+            "/wp-config.php.save",
+            "/wp-config.php~",
+            "/wp-config.php.swp",
+            "/wp-config-sample.php",
             "/config.json",
             "/config.yml",
             "/config.yaml",
             "/settings.json",
             "/settings.yml",
             "/web.config",
+            "/web.config.bak",
+            "/appsettings.json",
+            "/appsettings.Development.json",
+            "/appsettings.Production.json",
             "/application.properties",
+            "/application.yml",
+            "/application.yaml",
+            "/application-prod.properties",
+            "/application-dev.properties",
+            "/bootstrap.properties",
             "/config/database.yml",
             "/config/secrets.yml",
             "/config/app.yml",
+            "/config/config.yml",
+            "/config/application.yml",
+            // Rails master key / encrypted credentials
+            "/config/master.key",
+            "/config/credentials.yml.enc",
+            "/config/credentials/production.key",
+            "/config/credentials/production.yml.enc",
+            "/config/credentials/development.key",
+            "/config/credentials/staging.key",
+            // Django
+            "/settings.py",
+            "/local_settings.py",
+            "/app/settings.py",
+            "/config/settings.py",
+            "/settings/production.py",
+            "/settings/local.py",
+            // Magento
+            "/app/etc/local.xml",
+            "/app/etc/env.php",
+            "/app/etc/config.php",
+            // Drupal
+            "/sites/default/settings.php",
+            "/sites/default/settings.local.php",
+            "/sites/default/default.settings.php",
+            "/sites/default/files/private/",
+            // Joomla
+            "/configuration.php.bak",
+            "/configuration.php~",
+            "/configuration.php.save",
             // Git files
             "/.git/config",
             "/.git/HEAD",
             "/.git/index",
+            "/.git/logs/HEAD",
+            "/.git/refs/heads/master",
+            "/.git/refs/heads/main",
+            "/.git/info/exclude",
+            "/.git/description",
+            "/.git/packed-refs",
+            "/.git/COMMIT_EDITMSG",
+            "/.git/ORIG_HEAD",
+            "/.git/FETCH_HEAD",
             "/.gitignore",
+            "/.gitconfig",
+            "/.gitmodules",
+            "/.gitattributes",
+            // Subversion / Mercurial / Bazaar
+            "/.svn/entries",
+            "/.svn/wc.db",
+            "/.svn/format",
+            "/.svn/all-wcprops",
+            "/CVS/Entries",
+            "/CVS/Root",
+            "/.hg/hgrc",
+            "/.hg/store/00manifest.i",
+            "/.bzr/README",
+            "/.bzr/checkout/conflicts",
             // Package manager files
             "/package.json",
             "/package-lock.json",
             "/composer.json",
             "/composer.lock",
             "/yarn.lock",
+            "/pnpm-lock.yaml",
             "/Gemfile",
             "/Gemfile.lock",
             "/requirements.txt",
             "/Pipfile",
             "/Pipfile.lock",
-            // Database dumps
+            "/poetry.lock",
+            "/pyproject.toml",
+            "/go.mod",
+            "/go.sum",
+            "/Cargo.toml",
+            "/Cargo.lock",
+            "/auth.json", // Composer auth tokens
+            "/.npmrc",
+            "/.yarnrc",
+            "/.yarnrc.yml",
+            "/.pypirc",
+            // Database dumps (high value)
             "/backup.sql",
+            "/backup.sql.gz",
+            "/backup.sql.zip",
+            "/backup.sql.tar.gz",
             "/dump.sql",
+            "/dump.sql.gz",
             "/database.sql",
+            "/database.sql.gz",
             "/db.sql",
+            "/db.sql.gz",
             "/mysql.sql",
+            "/mysqldump.sql",
             "/postgres.sql",
+            "/pgdump.sql",
             "/data.sql",
+            "/prod.sql",
+            "/production.sql",
+            "/prod_backup.sql",
+            "/production_backup.sql",
+            "/users.sql",
+            "/customers.sql",
+            "/clients.sql",
+            "/orders.sql",
+            "/accounts.sql",
+            "/site.sql",
+            "/site_backup.sql",
+            "/latest.sql",
+            "/db_backup.sql",
+            "/database_backup.sql",
+            "/dump.rdb", // Redis persistent snapshot
+            "/mongodump.tar",
+            "/mongodump.tar.gz",
+            // Terraform / IaC state (contains ALL plaintext secrets)
+            "/terraform.tfstate",
+            "/terraform.tfstate.backup",
+            "/terraform.tfvars",
+            "/terraform.tfvars.json",
+            "/secret.tfvars",
+            "/secrets.tfvars",
+            "/prod.tfvars",
+            "/production.tfvars",
+            "/.terraform/terraform.tfstate",
+            "/.terraformrc",
             // Debug and info files
             "/phpinfo.php",
             "/info.php",
@@ -145,28 +273,186 @@ impl SensitiveDataScanner {
             "/debug.php",
             "/_debug",
             "/debug",
+            "/phpinfo",
+            "/pinfo.php",
+            "/i.php",
+            "/_profiler",     // Symfony profiler
+            "/_profiler/phpinfo",
+            "/elmah.axd",     // ASP.NET error log
+            "/trace.axd",     // ASP.NET tracing
+            "/server-status", // Apache mod_status
             // Log files
             "/logs/error.log",
             "/logs/access.log",
+            "/logs/debug.log",
+            "/logs/app.log",
+            "/logs/application.log",
+            "/logs/production.log",
             "/log/error.log",
+            "/log/production.log",
+            "/log/development.log",
             "/error.log",
             "/access.log",
             "/error_log",
             "/debug.log",
+            "/app.log",
+            "/laravel.log",
+            "/storage/logs/laravel.log",
+            "/nohup.out",
+            "/log.txt",
             // API documentation
             "/api/swagger.json",
             "/api-docs",
+            "/api-docs.json",
             "/swagger.json",
             "/swagger.yaml",
+            "/swagger-ui",
+            "/swagger-ui/index.html",
+            "/swagger/v1/swagger.json",
+            "/swagger/v2/swagger.json",
             "/openapi.json",
+            "/openapi.yaml",
+            "/openapi.yml",
             "/graphql",
+            "/graphiql",
             "/v1/api-docs",
+            "/v2/api-docs",
+            "/v3/api-docs",
             "/api/v1/swagger",
+            "/api/v2/swagger",
+            "/api/docs",
+            "/api/schema",
+            "/redoc",
             // Server status
-            "/server-status",
             "/server-info",
             "/status",
             "/health",
+            "/actuator",
+            "/actuator/env",
+            "/actuator/heapdump",
+            "/actuator/configprops",
+            // Cloud credentials & SDK configs
+            "/.aws/credentials",
+            "/.aws/config",
+            "/.boto",
+            "/.s3cfg",
+            "/s3cfg",
+            "/credentials.csv",      // AWS root/IAM credentials export
+            "/credentials.json",     // GCP / Firebase service account
+            "/service-account.json",
+            "/serviceaccount.json",
+            "/gcp-key.json",
+            "/gcloud-key.json",
+            "/firebase-adminsdk.json",
+            "/.gcloudignore",
+            "/.docker/config.json",
+            "/.dockercfg",
+            "/.kube/config",
+            "/kubeconfig",
+            "/azure.json",
+            "/azureProfile.json",
+            "/publishsettings",
+            "/WebDeploy.publishsettings",
+            // Private keys and certificates
+            "/id_rsa",
+            "/id_dsa",
+            "/id_ecdsa",
+            "/id_ed25519",
+            "/.ssh/id_rsa",
+            "/.ssh/id_dsa",
+            "/.ssh/id_ecdsa",
+            "/.ssh/id_ed25519",
+            "/.ssh/authorized_keys",
+            "/.ssh/known_hosts",
+            "/.ssh/config",
+            "/authorized_keys",
+            "/server.key",
+            "/server.pem",
+            "/private.key",
+            "/private.pem",
+            "/privkey.pem",
+            "/cert.pem",
+            "/certificate.pem",
+            "/key.pem",
+            "/client.key",
+            "/client.pem",
+            "/ca.key",
+            "/ca.pem",
+            "/ssl.key",
+            "/ssl.pem",
+            // Secret store files
+            "/secrets.yml",
+            "/secrets.yaml",
+            "/secrets.json",
+            "/secrets.env",
+            "/vault.json",
+            "/credentials.yml",
+            "/credentials.yaml",
+            // IDE / editor config (often contains DB + SSH creds)
+            "/.vscode/sftp.json",
+            "/.vscode/settings.json",
+            "/.vscode/launch.json",
+            "/.idea/workspace.xml",
+            "/.idea/dataSources.xml",
+            "/.idea/dataSources.local.xml",
+            "/.idea/webServers.xml",
+            "/.idea/deployment.xml",
+            "/.idea/WebServers.xml",
+            "/sftp-config.json",
+            "/ftpsync.settings",
+            "/nbproject/project.properties",
+            "/nbproject/private/private.properties",
+            // CI/CD configs
+            "/.travis.yml",
+            "/.circleci/config.yml",
+            "/.gitlab-ci.yml",
+            "/bitbucket-pipelines.yml",
+            "/azure-pipelines.yml",
+            "/Jenkinsfile",
+            "/jenkins.xml",
+            "/.drone.yml",
+            "/buildspec.yml",
+            "/codemagic.yaml",
+            // Container / orchestration
+            "/Dockerfile",
+            "/docker-compose.yml",
+            "/docker-compose.yaml",
+            "/docker-compose.override.yml",
+            "/docker-compose.prod.yml",
+            "/docker-compose.production.yml",
+            "/docker-compose.dev.yml",
+            "/.dockerignore",
+            // Shell history / dotfiles leaking credentials
+            "/.bash_history",
+            "/.zsh_history",
+            "/.sh_history",
+            "/.mysql_history",
+            "/.psql_history",
+            "/.irb_history",
+            "/.node_repl_history",
+            "/.rediscli_history",
+            "/.history",
+            "/.pgpass",
+            "/.my.cnf",
+            "/.netrc",
+            "/.netlify/state.json",
+            // Core dumps / heap dumps
+            "/core",
+            "/core.dump",
+            "/heapdump",
+            "/heapdump.hprof",
+            "/dump.hprof",
+            "/java_pid.hprof",
+            // ASP.NET, Java, PHP specific
+            "/appsettings.json.bak",
+            "/appsettings.json.old",
+            "/Web.config.bak",
+            "/Web.config.old",
+            "/WEB-INF/web.xml",
+            "/WEB-INF/classes/",
+            "/META-INF/MANIFEST.MF",
+            "/META-INF/context.xml",
+            "/.phpunit.result.cache",
             // Other sensitive files
             "/.DS_Store",
             "/robots.txt",
@@ -175,10 +461,42 @@ impl SensitiveDataScanner {
             "/admin/config",
             "/.htaccess",
             "/.htpasswd",
-            "/web.config.bak",
+            "/passwd",
+            "/.passwd",
+            "/users.txt",
+            "/password.txt",
+            "/passwords.txt",
+            "/secret.txt",
+            "/secrets.txt",
+            "/todo.txt",
+            "/TODO",
+            "/CHANGELOG",
+            "/CHANGELOG.md",
+            "/CHANGELOG.txt",
+            "/VERSION",
+            "/version.txt",
+            "/.well-known/openid-configuration",
+            // Archive backups (fast enum)
             "/backup.zip",
+            "/backup.tar.gz",
+            "/backup.tar",
+            "/backup.rar",
+            "/backup.7z",
             "/site.zip",
+            "/site.tar.gz",
+            "/site.tar",
             "/www.zip",
+            "/www.tar.gz",
+            "/html.zip",
+            "/public_html.zip",
+            "/public_html.tar.gz",
+            "/web.zip",
+            "/wwwroot.zip",
+            "/release.zip",
+            "/source.zip",
+            "/src.zip",
+            "/app.zip",
+            "/app.tar.gz",
         ]
     }
 
@@ -195,10 +513,538 @@ impl SensitiveDataScanner {
         }
 
         let body_lower = body.to_lowercase();
+        let path_lower = path.to_lowercase();
+
+        // Reject HTML error pages / SPA shells served as 200
+        // These tend to be the most common source of false positives.
+        if Self::looks_like_generic_html(&body_lower) {
+            return None;
+        }
+
+        // Private SSH/PEM key blocks - extremely high confidence, critical impact
+        if Self::contains_private_key_block(body) {
+            return Some(self.create_vulnerability(
+                "Private Key Exposed",
+                url,
+                &self.truncate_evidence(body, 200),
+                Severity::Critical,
+                "CWE-321",
+                9.8,
+                "Rotate the exposed private key immediately. Never store private keys in web-accessible locations.",
+            ));
+        }
+
+        // AWS credentials file (~/.aws/credentials)
+        if path_lower.ends_with("/.aws/credentials") || path_lower == "/.aws/credentials"
+            || path_lower.ends_with("/credentials.csv") {
+            if (body.contains("aws_access_key_id") && body.contains("aws_secret_access_key"))
+                || body.contains("AKIA")
+                || (body_lower.contains("access key id") && body_lower.contains("secret access key"))
+            {
+                return Some(self.create_vulnerability(
+                    "AWS Credentials File Exposed",
+                    url,
+                    &self.truncate_evidence(body, 200),
+                    Severity::Critical,
+                    "CWE-798",
+                    9.8,
+                    "Rotate all AWS credentials immediately. Delete the exposed file. Use IAM roles instead of long-lived keys.",
+                ));
+            }
+        }
+
+        // AWS SDK config file
+        if path_lower.ends_with("/.aws/config") {
+            if body.contains("[profile") || body.contains("[default]")
+                || body_lower.contains("region") && body_lower.contains("output") {
+                return Some(self.create_vulnerability(
+                    "AWS Config File Exposed",
+                    url,
+                    &self.truncate_evidence(body, 200),
+                    Severity::High,
+                    "CWE-200",
+                    7.5,
+                    "Remove .aws/config from web root. Check for accompanying credentials exposure.",
+                ));
+            }
+        }
+
+        // Kubernetes kubeconfig
+        if path_lower.ends_with("/.kube/config") || path_lower.ends_with("/kubeconfig") {
+            if (body_lower.contains("apiversion") && body_lower.contains("kind: config"))
+                || (body.contains("clusters:") && body.contains("contexts:") && body.contains("users:"))
+                || body.contains("client-certificate-data")
+                || body.contains("client-key-data")
+                || body.contains("certificate-authority-data")
+            {
+                return Some(self.create_vulnerability(
+                    "Kubernetes kubeconfig Exposed",
+                    url,
+                    &self.truncate_evidence(body, 200),
+                    Severity::Critical,
+                    "CWE-798",
+                    9.8,
+                    "Rotate cluster credentials immediately. Remove kubeconfig from web root. Use short-lived tokens.",
+                ));
+            }
+        }
+
+        // Docker config (contains registry auth tokens)
+        if path_lower.ends_with("/.docker/config.json") || path_lower.ends_with("/.dockercfg") {
+            if body.contains("\"auths\"") || body.contains("\"auth\":") || body.contains("\"credsStore\"") {
+                return Some(self.create_vulnerability(
+                    "Docker Registry Credentials Exposed",
+                    url,
+                    &self.truncate_evidence(body, 200),
+                    Severity::Critical,
+                    "CWE-798",
+                    9.1,
+                    "Rotate registry credentials immediately. Remove Docker config from web root.",
+                ));
+            }
+        }
+
+        // GCP / Firebase service account JSON
+        if path_lower.ends_with(".json")
+            && (body.contains("\"type\": \"service_account\"")
+                || body.contains("\"type\":\"service_account\"")
+                || (body.contains("\"private_key\"") && body.contains("-----BEGIN PRIVATE KEY-----")))
+        {
+            return Some(self.create_vulnerability(
+                "GCP/Firebase Service Account Key Exposed",
+                url,
+                &self.truncate_evidence(body, 200),
+                Severity::Critical,
+                "CWE-798",
+                9.8,
+                "Revoke the service account key immediately in the GCP console. Rotate and store securely.",
+            ));
+        }
+
+        // Terraform state file - contains ALL plaintext secrets (passwords, tokens, private keys)
+        if path_lower.ends_with(".tfstate") || path_lower.ends_with(".tfstate.backup") {
+            if (body.contains("\"terraform_version\"") && body.contains("\"resources\""))
+                || body.contains("\"serial\":")
+                || body.contains("\"lineage\"")
+            {
+                return Some(self.create_vulnerability(
+                    "Terraform State File Exposed",
+                    url,
+                    &self.truncate_evidence(body, 200),
+                    Severity::Critical,
+                    "CWE-200",
+                    9.8,
+                    "Terraform state stores all resource attributes in plaintext including passwords, tokens, and private keys. \
+                    Assume every secret referenced by this state is compromised. Migrate state to a remote backend (S3/GCS/Terraform Cloud) \
+                    with encryption and access controls. Rotate all secrets.",
+                ));
+            }
+        }
+
+        // Terraform variables file
+        if path_lower.ends_with(".tfvars") || path_lower.ends_with(".tfvars.json") {
+            let cred_keywords = ["password", "secret", "token", "api_key", "access_key", "private_key"];
+            if cred_keywords.iter().any(|k| body_lower.contains(k))
+                && (body.contains("=") || body.contains(":"))
+            {
+                return Some(self.create_vulnerability(
+                    "Terraform Variables File Exposed",
+                    url,
+                    &self.truncate_evidence(body, 200),
+                    Severity::Critical,
+                    "CWE-200",
+                    9.1,
+                    "Remove .tfvars files from web root. These often contain plaintext secrets. Rotate any exposed credentials.",
+                ));
+            }
+        }
+
+        // Rails master key (single 32-char hex/base32)
+        if path_lower.ends_with("/config/master.key") || path_lower.ends_with("/master.key")
+            || path_lower.contains("/credentials/") && path_lower.ends_with(".key") {
+            let trimmed = body.trim();
+            // Rails master keys are 32-character hex
+            if trimmed.len() >= 24 && trimmed.len() <= 128
+                && trimmed.chars().all(|c| c.is_ascii_hexdigit() || c == '\n' || c == '\r')
+            {
+                return Some(self.create_vulnerability(
+                    "Rails Master Key Exposed",
+                    url,
+                    "Rails master.key contents detected",
+                    Severity::Critical,
+                    "CWE-321",
+                    9.8,
+                    "Rotate the Rails master key and re-encrypt credentials.yml.enc. Never commit master.key to the web root.",
+                ));
+            }
+        }
+
+        // Rails encrypted credentials file - still worth flagging as exposure
+        if path_lower.ends_with("credentials.yml.enc") {
+            // Rails credentials files start with a specific binary-ish signature
+            if body.len() > 20 && !body_lower.contains("<html") {
+                return Some(self.create_vulnerability(
+                    "Rails Encrypted Credentials File Exposed",
+                    url,
+                    &self.truncate_evidence(body, 100),
+                    Severity::Medium,
+                    "CWE-200",
+                    5.3,
+                    "Remove credentials.yml.enc from web root. If master.key is also leaked, all credentials are compromised.",
+                ));
+            }
+        }
+
+        // .htpasswd file exposure (contains bcrypt/MD5 hashed user passwords)
+        if path_lower.ends_with("/.htpasswd") {
+            // Format: username:$2y$... or username:$apr1$...
+            if body.contains(":$2")
+                || body.contains(":$apr1$")
+                || body.contains(":{SHA}")
+                || body.contains(":$1$")
+                || body.contains(":$6$")
+            {
+                return Some(self.create_vulnerability(
+                    ".htpasswd File Exposed",
+                    url,
+                    &self.truncate_evidence(body, 150),
+                    Severity::Critical,
+                    "CWE-522",
+                    9.1,
+                    "Remove .htpasswd from web root. Password hashes can be cracked offline. Rotate all passwords and move the file outside DocumentRoot.",
+                ));
+            }
+        }
+
+        // .netrc / .pgpass / .my.cnf files
+        if path_lower.ends_with("/.netrc") {
+            if body.contains("machine ") && (body.contains("login ") || body.contains("password ")) {
+                return Some(self.create_vulnerability(
+                    ".netrc File Exposed",
+                    url,
+                    &self.truncate_evidence(body, 150),
+                    Severity::Critical,
+                    "CWE-522",
+                    9.1,
+                    "Rotate all credentials stored in the .netrc file. Remove from web root.",
+                ));
+            }
+        }
+
+        if path_lower.ends_with("/.pgpass") {
+            // Format: hostname:port:database:username:password
+            let lines: Vec<&str> = body.lines().filter(|l| !l.trim().is_empty() && !l.starts_with('#')).collect();
+            if lines.iter().any(|l| l.matches(':').count() >= 4) {
+                return Some(self.create_vulnerability(
+                    "PostgreSQL .pgpass File Exposed",
+                    url,
+                    "PostgreSQL credentials file format detected",
+                    Severity::Critical,
+                    "CWE-522",
+                    9.1,
+                    "Rotate all PostgreSQL passwords listed. Remove .pgpass from web root.",
+                ));
+            }
+        }
+
+        if path_lower.ends_with("/.my.cnf") {
+            if (body.contains("[client]") || body.contains("[mysql]") || body.contains("[mysqldump]"))
+                && (body_lower.contains("password") || body_lower.contains("user"))
+            {
+                return Some(self.create_vulnerability(
+                    "MySQL Client Config (.my.cnf) Exposed",
+                    url,
+                    &self.truncate_evidence(body, 150),
+                    Severity::Critical,
+                    "CWE-522",
+                    9.1,
+                    "Rotate MySQL credentials. Remove .my.cnf from web root.",
+                ));
+            }
+        }
+
+        // Shell history files
+        if path_lower.ends_with("/.bash_history")
+            || path_lower.ends_with("/.zsh_history")
+            || path_lower.ends_with("/.sh_history")
+            || path_lower.ends_with("/.mysql_history")
+            || path_lower.ends_with("/.psql_history")
+        {
+            let shell_indicators = ["cd ", "ls ", "sudo ", "ssh ", "mysql ", "psql ", "curl ", "wget ", "export ", "git ", "vi ", "nano "];
+            let hit = shell_indicators.iter().filter(|i| body.contains(*i)).count();
+            if hit >= 2 || body.contains("-u root") || body.contains("--password") {
+                return Some(self.create_vulnerability(
+                    "Shell History File Exposed",
+                    url,
+                    &self.truncate_evidence(body, 200),
+                    Severity::High,
+                    "CWE-532",
+                    7.5,
+                    "Shell history commonly contains passwords, tokens, and sensitive commands. Remove from web root and rotate any exposed credentials.",
+                ));
+            }
+        }
+
+        // ELMAH (ASP.NET) error log
+        if path_lower.ends_with("/elmah.axd") || path_lower.contains("/elmah.axd") {
+            if body.contains("ELMAH") || body.contains("Error Log") || body.contains("All Errors") {
+                return Some(self.create_vulnerability(
+                    "ELMAH Error Log Exposed",
+                    url,
+                    &self.truncate_evidence(body, 200),
+                    Severity::High,
+                    "CWE-200",
+                    7.5,
+                    "ELMAH exposes full stack traces, query strings, cookies, and server variables. Protect elmah.axd with authentication or remove from production.",
+                ));
+            }
+        }
+
+        // ASP.NET trace.axd
+        if path_lower.ends_with("/trace.axd") {
+            if body.contains("Application Trace") || body.contains("Request Details") || body.contains("Trace Information") {
+                return Some(self.create_vulnerability(
+                    "ASP.NET trace.axd Exposed",
+                    url,
+                    &self.truncate_evidence(body, 200),
+                    Severity::High,
+                    "CWE-200",
+                    7.5,
+                    "trace.axd exposes request/session details. Disable tracing in production web.config.",
+                ));
+            }
+        }
+
+        // Spring Boot Actuator heapdump / env (binary or JSON)
+        if path_lower.contains("/actuator/heapdump") || path_lower.ends_with("/heapdump") {
+            // Heap dumps are binary with HPROF magic header, or can be small error pages when disabled
+            let bytes = body.as_bytes();
+            if bytes.len() > 100
+                && (body.starts_with("JAVA PROFILE") || (bytes.len() >= 4 && &bytes[..4] == b"\x4a\x41\x56\x41"))
+            {
+                return Some(self.create_vulnerability(
+                    "Spring Boot Heap Dump Exposed",
+                    url,
+                    "HPROF heap dump data served",
+                    Severity::Critical,
+                    "CWE-200",
+                    9.1,
+                    "Heap dumps contain every string and object in JVM memory including passwords and tokens. Secure /actuator endpoints with authentication.",
+                ));
+            }
+        }
+
+        if path_lower.contains("/actuator/env") || path_lower == "/env" {
+            if body.contains("\"propertySources\"") || body.contains("\"activeProfiles\"")
+                || body.contains("systemEnvironment") {
+                return Some(self.create_vulnerability(
+                    "Spring Boot Actuator /env Exposed",
+                    url,
+                    &self.truncate_evidence(body, 200),
+                    Severity::High,
+                    "CWE-200",
+                    8.2,
+                    "Actuator /env endpoint exposes environment variables and property sources including database URLs and secrets. Protect actuator endpoints.",
+                ));
+            }
+        }
+
+        // IDE config leaking datasources / SSH targets
+        if path_lower.ends_with("/.idea/datasources.xml") || path_lower.ends_with("/.idea/datasources.local.xml") {
+            if body.contains("<DataSource") || body.contains("jdbc:") || body.contains("<datasource") {
+                return Some(self.create_vulnerability(
+                    "JetBrains IDE Data Source Configuration Exposed",
+                    url,
+                    &self.truncate_evidence(body, 200),
+                    Severity::High,
+                    "CWE-200",
+                    7.5,
+                    "dataSources.xml exposes database connection strings. Add .idea/ to .gitignore and remove from web root.",
+                ));
+            }
+        }
+
+        if path_lower.ends_with("/.vscode/sftp.json") || path_lower.ends_with("/sftp-config.json") {
+            if body.contains("\"host\"") && (body.contains("\"password\"") || body.contains("\"privateKeyPath\"") || body.contains("\"username\"")) {
+                return Some(self.create_vulnerability(
+                    "Editor SFTP Configuration Exposed",
+                    url,
+                    &self.truncate_evidence(body, 200),
+                    Severity::Critical,
+                    "CWE-522",
+                    9.1,
+                    "SFTP config leaks server hosts, usernames, and often passwords or key paths. Rotate credentials and remove from web root.",
+                ));
+            }
+        }
+
+        // Drupal settings.php
+        if path_lower.ends_with("/sites/default/settings.php")
+            || path_lower.ends_with("/sites/default/settings.local.php")
+        {
+            if body.contains("$databases") || body.contains("$settings['hash_salt']")
+                || body.contains("'driver' =>") {
+                return Some(self.create_vulnerability(
+                    "Drupal settings.php Exposed",
+                    url,
+                    &self.truncate_evidence(body, 200),
+                    Severity::Critical,
+                    "CWE-200",
+                    9.1,
+                    "Drupal settings.php contains database credentials and hash salt. Rotate credentials and secure the file.",
+                ));
+            }
+        }
+
+        // Magento local.xml / env.php
+        if path_lower.ends_with("/app/etc/local.xml") {
+            if body.contains("<username>") && body.contains("<password>") && body.contains("<dbname>") {
+                return Some(self.create_vulnerability(
+                    "Magento local.xml Exposed",
+                    url,
+                    &self.truncate_evidence(body, 200),
+                    Severity::Critical,
+                    "CWE-200",
+                    9.1,
+                    "Magento local.xml exposes database credentials and crypt key. Rotate credentials immediately.",
+                ));
+            }
+        }
+
+        if path_lower.ends_with("/app/etc/env.php") {
+            if body.contains("<?php") && body.contains("'db'") && body.contains("'connection'") {
+                return Some(self.create_vulnerability(
+                    "Magento 2 env.php Exposed",
+                    url,
+                    &self.truncate_evidence(body, 200),
+                    Severity::Critical,
+                    "CWE-200",
+                    9.1,
+                    "Magento 2 env.php exposes encryption key, database credentials and cache configuration. Rotate all secrets.",
+                ));
+            }
+        }
+
+        // Django settings
+        if path_lower.ends_with("/settings.py") || path_lower.ends_with("/local_settings.py")
+            || path_lower.ends_with("/settings/production.py") || path_lower.ends_with("/settings/local.py")
+        {
+            if body.contains("SECRET_KEY") && body.contains("=")
+                && (body.contains("DATABASES") || body.contains("INSTALLED_APPS"))
+            {
+                return Some(self.create_vulnerability(
+                    "Django settings.py Exposed",
+                    url,
+                    &self.truncate_evidence(body, 200),
+                    Severity::Critical,
+                    "CWE-200",
+                    9.1,
+                    "Django settings.py exposes SECRET_KEY and database credentials. Rotate SECRET_KEY (invalidates sessions) and DB passwords.",
+                ));
+            }
+        }
+
+        // appsettings.json (ASP.NET Core)
+        if path_lower.ends_with("/appsettings.json")
+            || path_lower.ends_with("/appsettings.development.json")
+            || path_lower.ends_with("/appsettings.production.json")
+        {
+            if (body.contains("\"ConnectionStrings\"") || body.contains("\"ConnectionString\""))
+                && body.contains("Password")
+            {
+                return Some(self.create_vulnerability(
+                    "ASP.NET Core appsettings.json Exposed",
+                    url,
+                    &self.truncate_evidence(body, 200),
+                    Severity::Critical,
+                    "CWE-200",
+                    9.1,
+                    "appsettings.json exposes connection strings with credentials. Use User Secrets or Azure Key Vault in production.",
+                ));
+            }
+        }
+
+        // WEB-INF/web.xml
+        if path_lower.contains("/web-inf/web.xml") {
+            if body.contains("<web-app") || body.contains("<servlet>") || body.contains("<filter>") {
+                return Some(self.create_vulnerability(
+                    "Java WEB-INF/web.xml Exposed",
+                    url,
+                    &self.truncate_evidence(body, 200),
+                    Severity::High,
+                    "CWE-200",
+                    7.5,
+                    "web.xml exposes servlet mappings, filters, and often context parameters with credentials. Block /WEB-INF/ at the web server layer.",
+                ));
+            }
+        }
+
+        // npmrc / composer auth.json
+        if path_lower.ends_with("/.npmrc") {
+            if body.contains("_authToken") || body.contains("//registry.npmjs.org/:_auth")
+                || body.contains("//npm.pkg.github.com/:_authToken")
+            {
+                return Some(self.create_vulnerability(
+                    ".npmrc With Auth Token Exposed",
+                    url,
+                    &self.truncate_evidence(body, 150),
+                    Severity::Critical,
+                    "CWE-798",
+                    9.1,
+                    "The .npmrc contains an npm/GitHub package registry auth token. Revoke the token and remove the file from the web root.",
+                ));
+            }
+        }
+
+        if path_lower.ends_with("/auth.json") {
+            if body.contains("\"http-basic\"") || body.contains("\"github-oauth\"")
+                || body.contains("\"gitlab-token\"") || body.contains("\"bearer\"")
+            {
+                return Some(self.create_vulnerability(
+                    "Composer auth.json Exposed",
+                    url,
+                    &self.truncate_evidence(body, 150),
+                    Severity::Critical,
+                    "CWE-798",
+                    9.1,
+                    "Composer auth.json contains package registry credentials. Revoke tokens and remove from web root.",
+                ));
+            }
+        }
+
+        // Redis RDB snapshot - binary signature
+        if path_lower.ends_with("/dump.rdb") {
+            if body.starts_with("REDIS") {
+                return Some(self.create_vulnerability(
+                    "Redis RDB Snapshot Exposed",
+                    url,
+                    "Redis database snapshot file served",
+                    Severity::Critical,
+                    "CWE-200",
+                    9.1,
+                    "dump.rdb contains the full Redis dataset including session data and cached credentials. Remove from web root.",
+                ));
+            }
+        }
 
         // .env file exposure
         if path.contains(".env") {
-            let env_patterns = ["db_password=", "api_key=", "secret_key=", "app_secret=", "aws_secret_access_key="];
+            let env_patterns = [
+                "db_password=",
+                "api_key=",
+                "secret_key=",
+                "app_secret=",
+                "aws_secret_access_key=",
+                "aws_access_key_id=",
+                "app_key=",
+                "database_url=",
+                "jwt_secret=",
+                "stripe_secret=",
+                "mail_password=",
+                "redis_password=",
+                "pusher_app_secret=",
+                "mailgun_secret=",
+            ];
             if env_patterns.iter().any(|p| body_lower.contains(p)) {
                 return Some(self.create_vulnerability(
                     "Environment File Exposed",
@@ -460,7 +1306,373 @@ impl SensitiveDataScanner {
             }
         }
 
+        // GitHub App / Server / User / Refresh tokens
+        if let Some(matches) = self.regex_scan(body, r"gh[suor]_[A-Za-z0-9_]{36,}") {
+            for evidence in matches.into_iter().take(2) {
+                vulnerabilities.push(self.create_vulnerability(
+                    "GitHub Token Exposed in Response",
+                    url,
+                    &evidence,
+                    Severity::Critical,
+                    "CWE-798",
+                    9.1,
+                    "Revoke the GitHub token immediately. Check audit logs for abuse.",
+                ));
+            }
+        }
+
+        // GitLab PAT
+        if let Some(matches) = self.regex_scan(body, r"glpat-[a-zA-Z0-9_\-]{20}") {
+            for evidence in matches.into_iter().take(2) {
+                vulnerabilities.push(self.create_vulnerability(
+                    "GitLab Personal Access Token Exposed",
+                    url,
+                    &evidence,
+                    Severity::Critical,
+                    "CWE-798",
+                    9.1,
+                    "Revoke the GitLab PAT immediately.",
+                ));
+            }
+        }
+
+        // OpenAI API key
+        if let Some(matches) = self.regex_scan(body, r"sk-[a-zA-Z0-9]{20,}T3BlbkFJ[a-zA-Z0-9]{20,}") {
+            for evidence in matches.into_iter().take(2) {
+                vulnerabilities.push(self.create_vulnerability(
+                    "OpenAI API Key Exposed in Response",
+                    url,
+                    &evidence,
+                    Severity::Critical,
+                    "CWE-798",
+                    9.1,
+                    "Revoke the OpenAI API key immediately. OpenAI keys enable billing abuse.",
+                ));
+            }
+        }
+
+        // Anthropic API key
+        if let Some(matches) = self.regex_scan(body, r"sk-ant-api[a-zA-Z0-9_\-]{32,}") {
+            for evidence in matches.into_iter().take(2) {
+                vulnerabilities.push(self.create_vulnerability(
+                    "Anthropic API Key Exposed in Response",
+                    url,
+                    &evidence,
+                    Severity::Critical,
+                    "CWE-798",
+                    9.1,
+                    "Revoke the Anthropic API key immediately.",
+                ));
+            }
+        }
+
+        // Stripe publishable+secret pair (secret is higher impact - already covered)
+        if let Some(matches) = self.regex_scan(body, r"rk_live_[a-zA-Z0-9]{24,}") {
+            for evidence in matches.into_iter().take(2) {
+                vulnerabilities.push(self.create_vulnerability(
+                    "Stripe Restricted Key Exposed in Response",
+                    url,
+                    &evidence,
+                    Severity::Critical,
+                    "CWE-798",
+                    9.1,
+                    "Rotate the Stripe restricted key. Scoped API keys still allow real operations.",
+                ));
+            }
+        }
+
+        // Twilio Account SID + Auth token patterns (pair indicates real leak)
+        if body.contains("AC") {
+            if let Some(matches) = self.regex_scan(body, r"AC[a-f0-9]{32}") {
+                // Only report if a plausible auth token is in the same response
+                let has_auth_token = self
+                    .regex_scan(body, r#"(?i)auth[_-]?token['"\s:=]{1,6}[a-f0-9]{32}"#)
+                    .is_some();
+                if has_auth_token {
+                    for evidence in matches.into_iter().take(2) {
+                        vulnerabilities.push(self.create_vulnerability(
+                            "Twilio Account SID + Auth Token Exposed",
+                            url,
+                            &evidence,
+                            Severity::Critical,
+                            "CWE-798",
+                            9.1,
+                            "Rotate the Twilio auth token immediately - attackers can send SMS/voice and incur charges.",
+                        ));
+                    }
+                }
+            }
+        }
+
+        // SendGrid API key
+        if let Some(matches) = self.regex_scan(body, r"SG\.[a-zA-Z0-9_\-]{22}\.[a-zA-Z0-9_\-]{43}")
+        {
+            for evidence in matches.into_iter().take(2) {
+                vulnerabilities.push(self.create_vulnerability(
+                    "SendGrid API Key Exposed in Response",
+                    url,
+                    &evidence,
+                    Severity::Critical,
+                    "CWE-798",
+                    9.1,
+                    "Revoke the SendGrid API key. Attackers can send mail from your domain.",
+                ));
+            }
+        }
+
+        // Square access / OAuth secret
+        if let Some(matches) = self.regex_scan(body, r"sq0(?:atp|csp)-[a-zA-Z0-9_\-]{22,43}") {
+            for evidence in matches.into_iter().take(2) {
+                vulnerabilities.push(self.create_vulnerability(
+                    "Square Token Exposed in Response",
+                    url,
+                    &evidence,
+                    Severity::Critical,
+                    "CWE-798",
+                    9.1,
+                    "Revoke the Square token immediately.",
+                ));
+            }
+        }
+
+        // Shopify tokens
+        if let Some(matches) = self.regex_scan(body, r"shp(?:at|pa|ss|ca)_[a-fA-F0-9]{32}") {
+            for evidence in matches.into_iter().take(2) {
+                vulnerabilities.push(self.create_vulnerability(
+                    "Shopify Token Exposed in Response",
+                    url,
+                    &evidence,
+                    Severity::Critical,
+                    "CWE-798",
+                    9.1,
+                    "Revoke the Shopify token; attackers can read or modify store data.",
+                ));
+            }
+        }
+
+        // HashiCorp Vault service token
+        if let Some(matches) = self.regex_scan(body, r"hvs\.[A-Za-z0-9_\-]{24,}") {
+            for evidence in matches.into_iter().take(2) {
+                vulnerabilities.push(self.create_vulnerability(
+                    "HashiCorp Vault Token Exposed",
+                    url,
+                    &evidence,
+                    Severity::Critical,
+                    "CWE-798",
+                    9.8,
+                    "Revoke the Vault token immediately and audit accessed paths.",
+                ));
+            }
+        }
+
+        // Doppler API key
+        if let Some(matches) = self.regex_scan(body, r"dp\.pt\.[A-Za-z0-9]{43}") {
+            for evidence in matches.into_iter().take(2) {
+                vulnerabilities.push(self.create_vulnerability(
+                    "Doppler API Key Exposed",
+                    url,
+                    &evidence,
+                    Severity::Critical,
+                    "CWE-798",
+                    9.8,
+                    "Revoke the Doppler service token - it provides access to all your secrets.",
+                ));
+            }
+        }
+
+        // Supabase service-role key (JWT with role=service_role)
+        if let Some(matches) = self.regex_scan(body, r"sbp_[a-fA-F0-9]{40}") {
+            for evidence in matches.into_iter().take(2) {
+                vulnerabilities.push(self.create_vulnerability(
+                    "Supabase Service Key Exposed",
+                    url,
+                    &evidence,
+                    Severity::Critical,
+                    "CWE-798",
+                    9.8,
+                    "Rotate the Supabase service_role key - it bypasses Row-Level Security.",
+                ));
+            }
+        }
+
+        // Netlify Personal Access Token
+        if let Some(matches) = self.regex_scan(body, r"nfp_[a-zA-Z0-9]{40}") {
+            for evidence in matches.into_iter().take(2) {
+                vulnerabilities.push(self.create_vulnerability(
+                    "Netlify Personal Access Token Exposed",
+                    url,
+                    &evidence,
+                    Severity::Critical,
+                    "CWE-798",
+                    9.1,
+                    "Revoke the Netlify token.",
+                ));
+            }
+        }
+
+        // Docker Hub personal access token
+        if let Some(matches) = self.regex_scan(body, r"dckr_pat_[a-zA-Z0-9_\-]{27}") {
+            for evidence in matches.into_iter().take(2) {
+                vulnerabilities.push(self.create_vulnerability(
+                    "Docker Hub Access Token Exposed",
+                    url,
+                    &evidence,
+                    Severity::High,
+                    "CWE-798",
+                    8.2,
+                    "Revoke the Docker Hub token and inspect push/pull logs.",
+                ));
+            }
+        }
+
+        // NPM token
+        if let Some(matches) = self.regex_scan(body, r"npm_[A-Za-z0-9]{36}") {
+            for evidence in matches.into_iter().take(2) {
+                vulnerabilities.push(self.create_vulnerability(
+                    "NPM Token Exposed",
+                    url,
+                    &evidence,
+                    Severity::Critical,
+                    "CWE-798",
+                    9.1,
+                    "Revoke the NPM automation/publish token.",
+                ));
+            }
+        }
+
+        // PyPI token
+        if let Some(matches) = self.regex_scan(body, r"pypi-AgEIcHlwaS5vcmc[A-Za-z0-9_\-]{40,}") {
+            for evidence in matches.into_iter().take(2) {
+                vulnerabilities.push(self.create_vulnerability(
+                    "PyPI API Token Exposed",
+                    url,
+                    &evidence,
+                    Severity::Critical,
+                    "CWE-798",
+                    9.1,
+                    "Revoke the PyPI API token - attackers can push malicious releases.",
+                ));
+            }
+        }
+
+        // MongoDB Atlas connection string with credentials
+        if let Some(matches) = self.regex_scan(
+            body,
+            r"mongodb(?:\+srv)?://[^:\s]+:[^@\s]+@[a-zA-Z0-9.-]+\.mongodb\.net",
+        ) {
+            for evidence in matches.into_iter().take(2) {
+                vulnerabilities.push(self.create_vulnerability(
+                    "MongoDB Atlas Connection String Exposed",
+                    url,
+                    &evidence,
+                    Severity::Critical,
+                    "CWE-798",
+                    9.8,
+                    "Rotate MongoDB Atlas DB user password and restrict source IPs.",
+                ));
+            }
+        }
+
+        // Generic "connection URL with embedded credentials"
+        // Strictly require scheme + user + pass + @ + host.TLD
+        if let Some(matches) = self.regex_scan(
+            body,
+            r#"(?:postgres(?:ql)?|mysql|redis|amqps?|mongodb(?:\+srv)?)://[A-Za-z0-9_][A-Za-z0-9_\-]*:[^@\s'"<>]+@[A-Za-z0-9][A-Za-z0-9.\-]+"#,
+        ) {
+            for evidence in matches.into_iter().take(2) {
+                vulnerabilities.push(self.create_vulnerability(
+                    "Database Connection String With Credentials Exposed",
+                    url,
+                    &evidence,
+                    Severity::Critical,
+                    "CWE-798",
+                    9.1,
+                    "Rotate the database password. Never expose connection strings client-side.",
+                ));
+            }
+        }
+
+        // Google OAuth client secret format
+        if let Some(matches) = self.regex_scan(body, r"GOCSPX-[a-zA-Z0-9_\-]{28}") {
+            for evidence in matches.into_iter().take(2) {
+                vulnerabilities.push(self.create_vulnerability(
+                    "Google OAuth Client Secret Exposed",
+                    url,
+                    &evidence,
+                    Severity::Critical,
+                    "CWE-798",
+                    9.1,
+                    "Rotate the Google OAuth client secret. Enable authorized origin/redirect restrictions.",
+                ));
+            }
+        }
+
+        // Firebase Cloud Messaging server key
+        if let Some(matches) = self.regex_scan(body, r"AAAA[A-Za-z0-9_\-]{7}:APA91[A-Za-z0-9_\-]{134,}") {
+            for evidence in matches.into_iter().take(2) {
+                vulnerabilities.push(self.create_vulnerability(
+                    "Firebase Cloud Messaging Server Key Exposed",
+                    url,
+                    &evidence,
+                    Severity::High,
+                    "CWE-798",
+                    8.2,
+                    "Rotate the FCM legacy server key; use HTTP v1 API with short-lived OAuth tokens.",
+                ));
+            }
+        }
+
+        // Private key block served in HTML/JSON response (not a file)
+        if Self::contains_private_key_block(body) {
+            vulnerabilities.push(self.create_vulnerability(
+                "Private Key Block Exposed in Response",
+                url,
+                "PEM/OpenSSH private key material served in response body",
+                Severity::Critical,
+                "CWE-321",
+                9.8,
+                "Rotate the key pair immediately. Audit where the private key was reachable from and remove it from any public surface.",
+            ));
+        }
+
         vulnerabilities
+    }
+
+    /// Detect whether a body is an HTML error/SPA shell rather than the requested file.
+    /// Heuristic: contains standard HTML and is not one of the signature-based file types we
+    /// already positively identify. This reduces false positives from 200 OK default pages.
+    fn looks_like_generic_html(body_lower: &str) -> bool {
+        let html_hits = [
+            "<!doctype html",
+            "<html",
+            "<head",
+            "<body",
+        ];
+        let hit_count = html_hits.iter().filter(|p| body_lower.contains(*p)).count();
+        if hit_count < 2 {
+            return false;
+        }
+        // Only treat as generic HTML if there's no structured machine data markers
+        // that could appear in sensitive files (e.g., JSON service accounts embedded
+        // on pages are extremely rare but possible).
+        !(body_lower.contains("\"private_key\"")
+            || body_lower.contains("-----begin")
+            || body_lower.contains("\"terraform_version\"")
+            || body_lower.contains("aws_access_key_id")
+            || body_lower.contains("<datasource"))
+    }
+
+    /// Detect PEM-encoded private key blocks. Extremely specific - these never appear in
+    /// legitimate HTML responses.
+    fn contains_private_key_block(body: &str) -> bool {
+        body.contains("-----BEGIN RSA PRIVATE KEY-----")
+            || body.contains("-----BEGIN DSA PRIVATE KEY-----")
+            || body.contains("-----BEGIN EC PRIVATE KEY-----")
+            || body.contains("-----BEGIN OPENSSH PRIVATE KEY-----")
+            || body.contains("-----BEGIN PGP PRIVATE KEY BLOCK-----")
+            || body.contains("-----BEGIN ENCRYPTED PRIVATE KEY-----")
+            || (body.contains("-----BEGIN PRIVATE KEY-----")
+                && body.contains("-----END PRIVATE KEY-----"))
     }
 
     /// Perform regex scan and return matches


### PR DESCRIPTION
Add high-impact sensitive-file paths and strict content detectors across the SensitiveDataScanner and InformationDisclosureScanner. New coverage targets credential/key material and full-data-disclosure surfaces while keeping detection signature-based to avoid false positives.

- sensitive_data.rs: grow get_sensitive_paths (env variants, Rails master key + encrypted credentials, Django/Magento/Drupal settings, Terraform state/tfvars, AWS/GCP/Azure/K8s/Docker configs, SSH private keys, authorized_keys, .htpasswd/.netrc/.pgpass/.my.cnf, shell histories, heapdumps, IDE SFTP and JetBrains datasources, CI/CD configs, Compose files, SQL/Redis dumps, archive backups, ELMAH/trace.axd, .npmrc/auth.json, WEB-INF/META-INF).
- sensitive_data.rs: analyze_sensitive_file gains strict signature checks for each new file type and a generic HTML / PEM private-key guard to cut false positives from SPA 200 shells.
- sensitive_data.rs: scan_for_credentials adds regex-backed detectors for GitHub server/user/OAuth tokens, GitLab PATs, OpenAI/Anthropic, Stripe restricted keys, SendGrid, Twilio SID+token pairs, Square, Shopify, Vault, Doppler, Supabase service key, Netlify/Docker Hub PAT, NPM/PyPI, Mongo Atlas, DB connection strings with creds, Google OAuth client secret, FCM server key, and in-body PEM private-key blocks.
- information_disclosure.rs: align test_sensitive_files path list with the above categories, per-file severity tiering via severity_for_sensitive_file (Critical for credential/key material), and extend detect_sensitive_content with signature-based checks for each new file family.

https://claude.ai/code/session_011DgVmiaBy37cfhii6RZtuB